### PR TITLE
Hikey: use stable strace v4.10 version

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -12,7 +12,7 @@
 	<default remote="optee" revision="master" />
 
         <!-- strace -->
-        <project remote="sfnet" path="strace" name="code" />
+        <project remote="sfnet" path="strace" name="code" revision="refs/tags/v4.10" />
 
 	<!-- l-loader -->
 	<!-- project remote="96boards" path="l-loader" name="l-loader" revision="master" /-->


### PR DESCRIPTION
Current version of strace is "master". This means it is
not a stable versionn, and may lead to compilation error
due to incompatible version of the components.

Latest stable version v4.10 is used instead

Change-Id: I0906606f4bfd67c4c4362bf428f30378066dad01
Signed-off-by: Pascal Brand <pascal.brand@st.com>