### PR TITLE
Latest busybox version cannot be used

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
 	<project path="optee_test" name="optee_test.git" />
 
 	<!-- busybox -->
-	<project remote="busybox" path="busybox" name="busybox.git" />
+	<project remote="busybox" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
 
 	<!-- Linux kernel -->
 	<project remote="linux" path="linux" name="linux.git" revision="refs/tags/v4.1-rc1"/>

--- a/fvp.xml
+++ b/fvp.xml
@@ -15,7 +15,7 @@
 	<project path="optee_test" name="optee_test.git" />
 
 	<!-- busybox -->
-	<project remote="busybox" path="busybox" name="busybox.git" />
+	<project remote="busybox" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
 
 	<!-- ARM gits, FVP -->
 	<!-- <project remote="arm" path="arm-trusted-firmware" name="arm-trusted-firmware.git" /> -->

--- a/hikey.xml
+++ b/hikey.xml
@@ -26,7 +26,7 @@
 	<project path="optee_test" name="optee_test" />
 
 	<!-- busybox -->
-	<project remote="busybox" path="busybox" name="busybox" />
+	<project remote="busybox" path="busybox" name="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
 
 	<!-- ARM gits -->
 	<!-- project remote="arm" path="arm-trusted-firmware" name="arm-trusted-firmware" /-->

--- a/mt8173-evb.xml
+++ b/mt8173-evb.xml
@@ -14,7 +14,7 @@
 	<project path="optee_test" name="optee_test.git" />
 
 	<!-- busybox -->
-	<project remote="busybox" path="busybox" name="busybox.git" />
+	<project remote="busybox" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
 
 	<!-- MediaTek Download Tool -->
 	<project remote="linaro-swg" path="mtk_tools" name="mtk_tools.git" />


### PR DESCRIPTION
busybox sha1 76915bf7 (2015-12-19) makes use of MTD_FILE_MODE_RAW.
This is correctly defined in linux/include/uapi/mtd/mtd-abi.h, but
unfortunately not in the toolchain headers
<toolchain>/arm-linux-gnueabihf/libc/usr/include/mtd/mtd-abi.h

Hence the previous sha1 is to be used, that is dbf5a6da

Change-Id: I6f96cd0cd23f0bcbfb18e719154e59d88d97379a
Tested-by: Pascal Brand <pascal.brand@linaro.org> (QEMU)
Signed-off-by: Pascal Brand <pascal.brand@st.com>