### PR TITLE
default: Update repo to use upstream

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -4,6 +4,7 @@
 	<remote name="linaro-swg" fetch="https://github.com/linaro-swg" />
 	<remote name="linux" fetch="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds" />
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
+	<remote name="qemu" fetch="https://github.com/qemu" />
 
 	<default remote="optee" revision="master" />
 
@@ -23,7 +24,7 @@
 	<project remote="linaro-swg" path="gen_rootfs" name="gen_rootfs.git" />
 	<project remote="linaro-swg" path="soc_term" name="soc_term.git" />
 	<project remote="linaro-swg" path="bios_qemu_tz_arm" name="bios_qemu_tz_arm.git" />
-	<project remote="linaro-swg" path="qemu" name="qemu.git" revision="c00ed157431a4a6e0c4c481ba1c809623cbf908f"/>
+	<project remote="qemu" path="qemu" name="qemu.git" />
 
 	<!-- Build -->
 	<project remote="optee" path="build" name="build.git">


### PR DESCRIPTION
Full TrustZone support landed in upstream QEMU as of commit
3c2c85ec4b112e3e2b899472314d5da6880fdf0e

Signed-off-by: Victor Chong <victor.chong@linaro.org>
Suggested-by: Peter Maydell <peter.maydell@linaro.org>
Tested-by: Victor Chong <victor.chong@linaro.org>