### PR TITLE
Add travis.xml, similar to QEMU (default.xml) but cloning with depth 1

### DIFF
--- a/travis.xml
+++ b/travis.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<remote name="busybox" fetch="git://busybox.net" />
+	<remote name="linaro-swg" fetch="https://github.com/linaro-swg" />
+	<remote name="linux" fetch="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds" />
+	<remote name="optee" fetch="https://github.com/OP-TEE" />
+	<remote name="qemu" fetch="https://github.com/qemu" />
+
+	<default remote="optee" revision="master" />
+
+	<!-- OP-TEE gits -->
+	<project path="optee_os" name="optee_os.git" clone-depth="1" />
+	<project path="optee_client" name="optee_client.git" clone-depth="1" />
+	<project path="optee_linuxdriver" name="optee_linuxdriver.git" clone-depth="1" />
+	<project path="optee_test" name="optee_test.git" clone-depth="1" />
+
+	<!-- busybox -->
+	<project remote="busybox" path="busybox" name="busybox.git" revision="refs/tags/1_24_1" clone-depth="1" />
+
+	<!-- Linux kernel -->
+	<project remote="linux" path="linux" name="linux.git" revision="refs/tags/v4.1-rc1" clone-depth="1" />
+
+	<!-- linaro-swg gits -->
+	<project remote="linaro-swg" path="gen_rootfs" name="gen_rootfs.git" clone-depth="1" />
+	<project remote="linaro-swg" path="soc_term" name="soc_term.git" clone-depth="1" />
+	<project remote="linaro-swg" path="bios_qemu_tz_arm" name="bios_qemu_tz_arm.git" clone-depth="1" />
+	<project remote="qemu" path="qemu" name="qemu.git" clone-depth="1" />
+
+	<!-- Build -->
+	<project remote="optee" path="build" name="build.git" clone-depth="1" >
+		<linkfile src="qemu.mk" dest="build/Makefile" />
+	</project>
+</manifest>


### PR DESCRIPTION
With this manifest, the "repo sync" phase on Travis takes less than one
minute vs. 4-6 minutes before.

travis.xml is created from default.xml and modified as follows:
- Add the clone-depth="1" attribute to all projects (shallow cloning)
- Change the BusyBox reference to the 1_24_0 tag. Previously, a SHA1
was used which would not work with shallow cloning.

Note that I could not get a similar result by simply using
"repo init --depth=1" (cloning would take longer).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>