### PR TITLE
mt8173: update for the generic driver

### DIFF
--- a/mt8173-evb.xml
+++ b/mt8173-evb.xml
@@ -2,7 +2,6 @@
 <manifest>
 	<remote name="busybox" fetch="git://busybox.net" />
 	<remote name="linaro-swg" fetch="https://github.com/linaro-swg" />
-	<remote name="linux" fetch="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds" />
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
 
 	<default remote="optee" revision="master" />
@@ -10,8 +9,10 @@
 	<!-- OP-TEE gits -->
 	<project path="optee_os" name="optee_os.git" />
 	<project path="optee_client" name="optee_client.git" />
-	<project path="optee_linuxdriver" name="optee_linuxdriver.git" />
 	<project path="optee_test" name="optee_test.git" />
+
+	<!-- ARM-TF -->
+	<project remote="linaro-swg" path="arm-trusted-firmware" name="arm-trusted-firmware.git" revision="mt8173_evb" />
 
 	<!-- busybox -->
 	<project remote="busybox" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
@@ -20,7 +21,7 @@
 	<project remote="linaro-swg" path="mtk_tools" name="mtk_tools.git" />
 
 	<!-- Linux kernel -->
-	<project remote="linux" path="linux" name="linux.git" revision="refs/tags/v4.1-rc1"/>
+	<project remote="linaro-swg" path="linux" name="linux.git" revision="optee" />
 
 	<!-- Filesystem -->
 	<project remote="linaro-swg" path="gen_rootfs" name="gen_rootfs.git" />


### PR DESCRIPTION
As soon as, https://github.com/linaro-swg/linux/pull/3 has been merged, this manifest will be complete to setup and run everything with the new generic TEE driver on the MT8173-EVB device.

This manifest update contains more or less the same as in #20 , however, this points to the correct remote gits. I.e, #20 can be closed if and when this has been merged.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (MT8173-EVB)