### PR TITLE
Point RPi3's hello world to master

### DIFF
--- a/rpi3_experimental.xml
+++ b/rpi3_experimental.xml
@@ -28,7 +28,8 @@
 	<project path="u-boot" name="u-boot.git" />
 
 	<!-- Hello world TA -->
-	<project remote="linaro-swg" path="hello_world" name="hello_world.git" />
+	<project remote="linaro-swg" path="hello_world" name="hello_world.git"
+	  revision="master" />
 
 	<!-- Filesystem -->
 	<project remote="linaro-swg" path="gen_rootfs" name="gen_rootfs.git" revision="master" />


### PR DESCRIPTION
With the default clause setting a default revision, the hello world
repository fails to sync because there is only a master branch.
Override the default to point back to the master branch.

Change-Id: Id4d9a425a544f4470be04f80020f9fe25669c0f8
Signed-off-by: David Brown <david.brown@linaro.org>