### PR TITLE
rpi3: All remotes now pointing to official gits

### DIFF
--- a/rpi3_experimental.xml
+++ b/rpi3_experimental.xml
@@ -2,42 +2,37 @@
 <manifest>
 	<!-- <remote name="busybox" fetch="git://busybox.net" /> -->
 	<remote name="busybox_mirror" fetch="https://github.com/mirror" />
-	<remote name="jbech" fetch="https://github.com/jbech-linaro" />
 	<remote name="linaro-swg" fetch="https://github.com/linaro-swg" />
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
 
-	<!-- Temporary until patches are good enough to be put on the offical
-	     upstream repositories -->
-	<default remote="jbech" revision="rpi3_initial_drop" />
-
 	<!-- OP-TEE gits -->
-	<project path="optee_os" name="optee_os.git" />
+	<project remote="optee" path="optee_os" name="optee_os.git" revision="master" />
 	<project remote="optee" path="optee_client" name="optee_client.git" revision="master" />
 	<project remote="optee" path="optee_test" name="optee_test.git" revision="master" />
 
-	<!-- busybox -->
+	<!-- BusyBox -->
 	<!-- <project remote="busybox" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" /> -->
 	<project remote="busybox_mirror" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
 
-	<project path="arm-trusted-firmware" name="arm-trusted-firmware.git" />
+	<!-- ARM Trusted Firmware -->
+	<project remote="linaro-swg" path="arm-trusted-firmware" name="arm-trusted-firmware.git" revision="rpi3_initial_drop"/>
 
 	<!-- Linux kernel -->
-	<project path="linux" name="linux.git" />
+	<project remote="linaro-swg" path="linux" name="linux.git" revision="electron752-rpi3-optee" />
 
 	<!-- U-boot -->
-	<project path="u-boot" name="u-boot.git" />
+	<project remote="linaro-swg" path="u-boot" name="u-boot.git" revision="rpi3_initial_drop"/>
 
 	<!-- Hello world TA -->
-	<project remote="linaro-swg" path="hello_world" name="hello_world.git"
-	  revision="master" />
+	<project remote="linaro-swg" path="hello_world" name="hello_world.git" revision="master" />
 
 	<!-- Filesystem -->
 	<project remote="linaro-swg" path="gen_rootfs" name="gen_rootfs.git" revision="master" />
 
 	<!-- Build -->
-	<project path="build" name="build.git">
+	<project remote="optee" path="build" name="build.git" revision="master">
 		<linkfile src="rpi3.mk" dest="build/Makefile" />
-		<linkfile src="rpi3/pi3.cfg" dest="build/pi3.cfg" />
+		<linkfile src="rpi3/debugger/pi3.cfg" dest="build/pi3.cfg" />
 		<linkfile src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb" dest="build/gdb" />
 	</project>
 </manifest>


### PR DESCRIPTION
Prior to this commit, there was a few remotes pointing to non-Linaro
gits (optee_os, build etc), but since everything has been merged to the
official gits and branches we have update the manifest accordingly.

Change-Id: Ibd3c4782f22d31c576986a80f949318d2bbfb94d
Signed-off-by: Joakim Bech <joakim.bech@linaro.org>