### PR TITLE
mtk8173: Update repos used in mtk8173

### DIFF
--- a/mt8173-evb.xml
+++ b/mt8173-evb.xml
@@ -17,8 +17,9 @@
 	<!-- busybox -->
 	<project remote="busybox" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
 
-	<!-- MediaTek Download Tool -->
+	<!-- MediaTek Download Tools -->
 	<project remote="linaro-swg" path="mtk_tools" name="mtk_tools.git" />
+	<project remote="linaro-swg" path "evb-utils" name="evb-utils.git" />
 
 	<!-- Linux kernel -->
 	<project remote="linaro-swg" path="linux" name="linux.git" revision="optee" />

--- a/mt8173-evb.xml
+++ b/mt8173-evb.xml
@@ -24,6 +24,9 @@
 	<!-- Linux kernel -->
 	<project remote="linaro-swg" path="linux" name="linux.git" revision="optee" />
 
+	<!-- Hello world TA -->
+	<project remote="linaro-swg" path="hello_world" name="hello_world.git" />
+
 	<!-- Filesystem -->
 	<project remote="linaro-swg" path="gen_rootfs" name="gen_rootfs.git" />
 


### PR DESCRIPTION
evb-utils contains scripts and binaries for updating the preloader,
which is necessary to be able to build and flash ARM-TF from scratch for
example.

The update procedure is as stated here:
 1. cd <repo_root>/evb-utils
 2. $ ./update-recover.sh
 3. Hold the download key pressed, then press reset key
 4. $ ./update.sh
 5. Device should now just wait in fastboot ready to flash the rest of
    the binaries.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>