### PR TITLE
travis.xml: checkout QEMU commit c5d128f because master is broken

### DIFF
--- a/travis.xml
+++ b/travis.xml
@@ -25,7 +25,8 @@
 	<project remote="linaro-swg" path="bios_qemu_tz_arm" name="bios_qemu_tz_arm.git" clone-depth="1" />
 	<project remote="linaro-swg" path="hello_world" name="hello_world.git" />
 
-	<project remote="qemu" path="qemu" name="qemu.git" clone-depth="1" />
+	<!-- Temporary use the defined commit since upstream tip didn't work -->
+	<project remote="qemu" path="qemu" name="qemu.git" revision="c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064" clone-depth="1" />
 
 	<!-- Build -->
 	<project remote="optee" path="build" name="build.git" clone-depth="1" >


### PR DESCRIPTION
QEMU master needs the following patch before we can use it again:
https://lists.gnu.org/archive/html/qemu-devel/2016-10/msg01979.html

Change-Id: Ic49fdfd83594b68d566990a411743f027dbd7778
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>