### PR TITLE
travis.xml: remove clone-depth="1"

### DIFF
--- a/travis.xml
+++ b/travis.xml
@@ -26,7 +26,7 @@
 	<project remote="linaro-swg" path="hello_world" name="hello_world.git" />
 
 	<!-- Temporary use the defined commit since upstream tip didn't work -->
-	<project remote="qemu" path="qemu" name="qemu.git" revision="c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064" clone-depth="1" />
+	<project remote="qemu" path="qemu" name="qemu.git" revision="c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064" />
 
 	<!-- Build -->
 	<project remote="optee" path="build" name="build.git" clone-depth="1" >


### PR DESCRIPTION
Clone depth cannot be used when a revision is specified. It results in:
  error: no such remote ref c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064

Change-Id: I12b501ae2dbe40452814745085009285cc474c36
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>