### PR TITLE
mtk8173: Correct the line for evb-utils

### DIFF
--- a/mt8173-evb.xml
+++ b/mt8173-evb.xml
@@ -19,7 +19,7 @@
 
 	<!-- MediaTek Download Tools -->
 	<project remote="linaro-swg" path="mtk_tools" name="mtk_tools.git" />
-	<project remote="linaro-swg" path "evb-utils" name="evb-utils.git" />
+	<project remote="linaro-swg" path="evb-utils" name="evb-utils.git" />
 
 	<!-- Linux kernel -->
 	<project remote="linaro-swg" path="linux" name="linux.git" revision="optee" />


### PR DESCRIPTION
So, now I've tried syncing and building from this branch, i.e.,
```
repo init -u https://github.com/jbech-linaro/manifest.git -m mt8173-evb.xml -b mtk_xml_error
```

I got the source code and and it built, so now I hope there shouldn't be any mistakes. Apologize for the sloppiness.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>