### PR TITLE
rpi3: update linux branch

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -18,7 +18,7 @@
 	<project remote="linaro-swg" path="arm-trusted-firmware" name="arm-trusted-firmware.git" revision="rpi3_initial_drop"/>
 
 	<!-- Linux kernel -->
-	<project remote="linaro-swg" path="linux" name="linux.git" revision="electron752-rpi3-optee" />
+	<project remote="linaro-swg" path="linux" name="linux.git" revision="electron752-rpi3-4.8-optee" />
 
 	<!-- U-boot -->
 	<project remote="linaro-swg" path="u-boot" name="u-boot.git" revision="rpi3_initial_drop"/>


### PR DESCRIPTION
Switch to the 4.8 linux kernel (based on raspberrypi 4.8 custom kernel +
applied OP-TEE patched). For details see: 
https://github.com/linaro-swg/linux/commits/electron752-rpi3-4.8-optee

All `xtest` testcases are successfully passed:
```
$ /bin/xtest
.....
23520 subtests of which 0 failed
69 test cases of which 0 failed
0 test case was skipped
TEE test application done!

root@RPi3:/tmp uname -a
Linux RPi3 4.8.15-v8 #1 SMP Wed Jan 4 15:14:58 EET 2017 aarch64 GNU/Linux

```
`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`