### PR TITLE
dra7xx: Use upstream OP-TEE repo for DRA7xx

### DIFF
--- a/dra7xx.xml
+++ b/dra7xx.xml
@@ -3,23 +3,22 @@
 	<remote name="busybox" fetch="git://busybox.net" />
 	<remote name="linaro-swg" fetch="https://github.com/linaro-swg" />
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
-	<remote name="ti-optee" fetch="git://git.ti.com/optee" />
 	<remote name="ti-u-boot" fetch="git://git.ti.com/ti-u-boot" />
 	<remote name="ti-linux" fetch="git://git.ti.com/ti-linux-kernel" />
 
 	<!-- OP-TEE gits -->
-	<project remote="ti-optee" path="optee_os" name="ti-optee-os.git" revision="ti_optee_os" />
-	<project remote="ti-optee" path="optee_client" name="ti-optee-client.git" revision="ti_optee_client" />
-	<project remote="ti-optee" path="optee_test" name="ti-optee-test.git" revision="ti_optee_test" />
+	<project remote="optee" path="optee_os" name="optee_os.git" revision="master" />
+	<project remote="optee" path="optee_client" name="optee_client.git" revision="master" />
+	<project remote="optee" path="optee_test" name="optee_test.git" revision="master" />
 
 	<!-- busybox -->
 	<project remote="busybox" path="busybox" name="busybox.git" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02" />
 
 	<!-- U-Boot -->
-	<project remote="ti-u-boot" path="u-boot" name="ti-u-boot.git" revision="ti-u-boot-2016.05" />
+	<project remote="ti-u-boot" path="u-boot" name="ti-u-boot.git" revision="ti-u-boot-2017.01" />
 
 	<!-- Linux kernel -->
-	<project remote="ti-linux" path="linux" name="ti-linux-kernel.git" revision="ti-lsk-linux-4.4.y" />
+	<project remote="ti-linux" path="linux" name="ti-linux-kernel.git" revision="ti-lsk-linux-4.9.y" />
 
 	<!-- Hello world TA -->
 	<project remote="linaro-swg" path="hello_world" name="hello_world.git" revision="master" />


### PR DESCRIPTION
Now that DRA7xx platform handlers are merged upstream we can
use the official OP-TEE repo for DRA7xx.

Also move Linux and U-Boot to latest internal LTS.

Signed-off-by: Andrew F. Davis <afd@ti.com>