### PR TITLE
Stable 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,62 @@
+# Travis configuration file for downloading and building OP-TEE according to the
+# instructions in build.git
+language: bash
+
+notifications:
+  email:
+    recipients:
+      - joakim.bech@linaro.org
+    on_success: change
+    on_failure: always
+
+dist: trusty
+sudo: required
+group: beta
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  depth: 10
+
+after_script:
+  - ccache -s
+
+before_install:
+  - ccache -s
+  - sudo dpkg --add-architecture i386
+  - sudo apt-get update -qq
+  # Package list taken from README.md
+  - sudo apt-get install -qq -y android-tools-adb android-tools-fastboot autoconf automake bc bison build-essential cscope curl device-tree-compiler flex ftp-upload gdisk iasl libattr1-dev libc6:i386 libcap-dev libfdt-dev libftdi-dev libglib2.0-dev libhidapi-dev libncurses5-dev libpixman-1-dev libssl-dev libstdc++6:i386 libtool libz1:i386 make mtools netcat python-crypto python-serial python-wand unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev
+
+install: true
+
+env:
+  - $REPO_PROJ=default
+  - $REPO_PROJ=fvp
+  - $REPO_PROJ=hikey
+  - $REPO_PROJ=juno
+  - $REPO_PROJ=mt8173-evb
+  - $REPO_PROJ=qemu_v8
+  - $REPO_PROJ=rpi3
+  #- $REPO_PROJ=dra7xx # Cannot build this since it requires TI_SECURE_DEV_PKG
+
+before_script:
+  - mkdir $HOME/bin
+  - cd $HOME/bin && wget https://storage.googleapis.com/git-repo-downloads/repo && chmod +x repo
+  - export PATH=$HOME/bin:$PATH
+  - mkdir -p $HOME/$REPO_PROJ
+
+script:
+  # Special case for FVP, since we check for the Foundation_Platformpkg folder
+  # in the makefile.
+  - if [ $REPO_PROJ == "fvp" ]; then mkdir -p $HOME/$REPO_PROJ/Foundation_Platformpkg; fi
+  # Use the manifest from the branch itself we're pushing to.
+  - echo "Getting ${REPO_PROJ}_stable.xml from https://github.com/$TRAVIS_REPO_SLUG using branch $TRAVIS_BRANCH"
+  - cd $HOME/$REPO_PROJ && repo init -u https://github.com/$TRAVIS_REPO_SLUG -b $TRAVIS_BRANCH -m ${REPO_PROJ}_stable.xml </dev/null && repo sync -j2 --no-clone-bundle --no-tags --quiet
+  # Fetch a local copy of dtc+libfdt to avoid issues with a possibly outdated libfdt-dev
+  - if [ $REPO_PROJ == "qemu_v8" ]; then cd $HOME/$REPO_PROJ/qemu && git submodule update --init dtc; fi
+  # Dump the content of the manifest (for debug purpose)
+  - cat $HOME/$REPO_PROJ/.repo/manifests/${REPO_PROJ}_stable.xml
+  - cd $HOME/$REPO_PROJ/build && make -f toolchain.mk toolchains -j3 && make all -j`nproc`

--- a/default_stable.xml
+++ b/default_stable.xml
@@ -5,17 +5,17 @@
   <remote fetch="https://github.com/OP-TEE" name="optee"/>
   <remote fetch="https://github.com/qemu" name="qemu"/>
   <default remote="optee" revision="master"/>
-  <project name="bios_qemu_tz_arm.git" path="bios_qemu_tz_arm" remote="linaro-swg" revision="c2f9a87aeed8574f728f0813e9a5a5334b7e9b22" upstream="master"/>
-  <project name="build.git" path="build" revision="refs/tags/2.3.0" upstream="master">
+  <project name="bios_qemu_tz_arm.git" path="bios_qemu_tz_arm" remote="linaro-swg" revision="c076d8e4caa25597e72d81a01b594e3d0c8e7a5f"/>
+  <project name="build.git" path="build" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="qemu.mk"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="18f93163b1b7d598720a0c2fd23a76d4c4a8b6ac" upstream="optee"/>
-  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="qemu.git" path="qemu" remote="qemu" revision="c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064" upstream="master"/>
-  <project name="soc_term.git" path="soc_term" remote="linaro-swg" revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" upstream="master"/>
+  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="961993fde60ebd06715d1433f8eb265471a0f38c"/>
+  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.4.0"/>
+  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.4.0"/>
+  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.4.0"/>
+  <project name="qemu.git" path="qemu" remote="qemu" revision="c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064"/>
+  <project name="soc_term.git" path="soc_term" remote="linaro-swg" revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20"/>
 </manifest>

--- a/dra7xx_stable.xml
+++ b/dra7xx_stable.xml
@@ -4,17 +4,16 @@
   <remote fetch="https://github.com/linaro-swg" name="linaro-swg"/>
   <remote fetch="https://github.com/OP-TEE" name="optee"/>
   <remote fetch="git://git.ti.com/ti-linux-kernel" name="ti-linux"/>
-  <remote fetch="git://git.ti.com/optee" name="ti-optee"/>
   <remote fetch="git://git.ti.com/ti-u-boot" name="ti-u-boot"/>
-  <project name="build.git" path="build" remote="optee" revision="refs/tags/2.3.0">
+  <project name="build.git" path="build" remote="optee" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="dra7xx.mk"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="ti-linux-kernel.git" path="linux" remote="ti-linux" revision="7c580a51af521f320eb56717f291aa5b64c2f244"/>
-  <project name="ti-optee-client.git" path="optee_client" remote="ti-optee" revision="ce5fefe6cba5df9b4f31399b1155ba768eee0b78"/>
-  <project name="ti-optee-os.git" path="optee_os" remote="ti-optee" revision="4556015010dbf648d236a72857e927317b0f6438"/>
-  <project name="ti-optee-test.git" path="optee_test" remote="ti-optee" revision="6203b8769beff4eccf7104a6474991114691bf90"/>
-  <project name="ti-u-boot.git" path="u-boot" remote="ti-u-boot" revision="593a89738a59aaf91a24f1ed174ef55b13131fa0"/>
+  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="optee_client.git" path="optee_client" remote="optee" revision="refs/tags/2.4.0"/>
+  <project name="optee_os.git" path="optee_os" remote="optee" revision="refs/tags/2.4.0"/>
+  <project name="optee_test.git" path="optee_test" remote="optee" revision="refs/tags/2.4.0"/>
+  <project name="ti-linux-kernel.git" path="linux" remote="ti-linux" revision="b84b1cb37f3dbfb61bd6bd447d600184ac484bd3"/>
+  <project name="ti-u-boot.git" path="u-boot" remote="ti-u-boot" revision="41459f659837cce32fd590693f350d0b662ba39d"/>
 </manifest>

--- a/fvp_stable.xml
+++ b/fvp_stable.xml
@@ -6,16 +6,16 @@
   <remote fetch="https://github.com/linaro-swg" name="linaro-swg"/>
   <remote fetch="https://github.com/OP-TEE" name="optee"/>
   <default remote="optee" revision="master"/>
-  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="69fb412f18ee40f9f7707da0d7411aada5ab60a0" upstream="optee_paged_armtf_v1.2"/>
-  <project name="build.git" path="build" revision="refs/tags/2.3.0" upstream="master">
+  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="0d6e84bc2c68de1602de6fbadeae109eb8298c18"/>
+  <project name="build.git" path="build" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="fvp.mk"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="18f93163b1b7d598720a0c2fd23a76d4c4a8b6ac" upstream="optee"/>
-  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="working/arm/edk2.git" path="edk2" remote="landing-teams" revision="131aec010f565a747ac51e6a95e30a37b5df15cc" upstream="16.01"/>
+  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="961993fde60ebd06715d1433f8eb265471a0f38c"/>
+  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.4.0"/>
+  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.4.0"/>
+  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.4.0"/>
+  <project name="working/arm/edk2.git" path="edk2" remote="landing-teams" revision="131aec010f565a747ac51e6a95e30a37b5df15cc"/>
 </manifest>

--- a/hikey_debian_stable.xml
+++ b/hikey_debian_stable.xml
@@ -7,19 +7,19 @@
   <remote fetch="git://git.savannah.gnu.org" name="savannah"/>
   <remote fetch="git://git.code.sf.net/p/strace" name="sfnet"/>
   <default remote="optee" revision="master"/>
-  <project name="arm-trusted-firmware" remote="96b-hk" revision="63655eba61d1739fd710f34fbe7ba8df3873ac4f" upstream="hikey"/>
-  <project name="build" revision="refs/tags/2.3.0" upstream="master">
+  <project name="arm-trusted-firmware" remote="96b-hk" revision="4adfdd06f11deb2ab6a056a68ed6f22dcb99a791"/>
+  <project name="build" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="hikey_debian.mk"/>
   </project>
-  <project name="burn-boot" remote="96boards" revision="db522b114fdec4d06d0a1705501fedc277903453" upstream="master"/>
-  <project name="code" path="strace" remote="sfnet" revision="ca2bf7c9e9b7f1b82a77d400ca9691806f1cbfc8" upstream="master"/>
-  <project name="edk2" remote="96boards" revision="7da6cdf18127ee52e79f3cf990c8d630fd037784" upstream="hikey"/>
-  <project name="grub" remote="savannah" revision="972765fe8245cdf44d465329f33b5aa9ac6c2f47" upstream="master"/>
-  <project name="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="l-loader" remote="96b-hk" revision="cddd213c1b820d5f224d20b38581c504552dd59e" upstream="master"/>
-  <project name="linux" remote="linaro-swg" revision="18f93163b1b7d598720a0c2fd23a76d4c4a8b6ac" upstream="optee"/>
-  <project name="optee_client" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="patches_hikey" remote="linaro-swg" revision="5fa1827551f8850ea010b43ab88e2072f4167912" upstream="master"/>
+  <project name="burn-boot" remote="96boards" revision="db522b114fdec4d06d0a1705501fedc277903453"/>
+  <project name="code" path="strace" remote="sfnet" revision="7f6f12a829c8f3ba2b8bd5d821e3f34ab197bccb"/>
+  <project name="edk2" remote="96boards" revision="7da6cdf18127ee52e79f3cf990c8d630fd037784"/>
+  <project name="grub" remote="savannah" revision="007f0b407f72314ec832d77e15b83ea40b160037"/>
+  <project name="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="l-loader" remote="96b-hk" revision="cddd213c1b820d5f224d20b38581c504552dd59e"/>
+  <project name="linux" remote="linaro-swg" revision="961993fde60ebd06715d1433f8eb265471a0f38c"/>
+  <project name="optee_client" revision="refs/tags/2.4.0"/>
+  <project name="optee_os" revision="refs/tags/2.4.0"/>
+  <project name="optee_test" revision="refs/tags/2.4.0"/>
+  <project name="patches_hikey" remote="linaro-swg" revision="93d4254c66003cacd9f7e84dd6b5831ab43b5265"/>
 </manifest>

--- a/hikey_stable.xml
+++ b/hikey_stable.xml
@@ -8,21 +8,21 @@
   <remote fetch="git://git.savannah.gnu.org" name="savannah"/>
   <remote fetch="git://git.code.sf.net/p/strace" name="sfnet"/>
   <default remote="optee" revision="master"/>
-  <project name="arm-trusted-firmware" remote="96b-hk" revision="63655eba61d1739fd710f34fbe7ba8df3873ac4f" upstream="hikey"/>
-  <project name="build" revision="refs/tags/2.3.0" upstream="master">
+  <project name="arm-trusted-firmware" remote="96b-hk" revision="4adfdd06f11deb2ab6a056a68ed6f22dcb99a791"/>
+  <project name="build" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="hikey.mk"/>
   </project>
-  <project name="burn-boot" remote="96boards" revision="db522b114fdec4d06d0a1705501fedc277903453" upstream="master"/>
+  <project name="burn-boot" remote="96boards" revision="db522b114fdec4d06d0a1705501fedc277903453"/>
   <project name="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="code" path="strace" remote="sfnet" revision="ca2bf7c9e9b7f1b82a77d400ca9691806f1cbfc8" upstream="master"/>
-  <project name="edk2" remote="96boards" revision="7da6cdf18127ee52e79f3cf990c8d630fd037784" upstream="hikey"/>
-  <project name="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="grub" remote="savannah" revision="972765fe8245cdf44d465329f33b5aa9ac6c2f47" upstream="master"/>
-  <project name="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="l-loader" remote="96b-hk" revision="cddd213c1b820d5f224d20b38581c504552dd59e" upstream="master"/>
-  <project name="linux" remote="linaro-swg" revision="18f93163b1b7d598720a0c2fd23a76d4c4a8b6ac" upstream="optee"/>
-  <project name="optee_client" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="patches_hikey" remote="linaro-swg" revision="5fa1827551f8850ea010b43ab88e2072f4167912" upstream="master"/>
+  <project name="code" path="strace" remote="sfnet" revision="7f6f12a829c8f3ba2b8bd5d821e3f34ab197bccb"/>
+  <project name="edk2" remote="96boards" revision="7da6cdf18127ee52e79f3cf990c8d630fd037784"/>
+  <project name="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="grub" remote="savannah" revision="007f0b407f72314ec832d77e15b83ea40b160037"/>
+  <project name="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="l-loader" remote="96b-hk" revision="cddd213c1b820d5f224d20b38581c504552dd59e"/>
+  <project name="linux" remote="linaro-swg" revision="961993fde60ebd06715d1433f8eb265471a0f38c"/>
+  <project name="optee_client" revision="refs/tags/2.4.0"/>
+  <project name="optee_os" revision="refs/tags/2.4.0"/>
+  <project name="optee_test" revision="refs/tags/2.4.0"/>
+  <project name="patches_hikey" remote="linaro-swg" revision="93d4254c66003cacd9f7e84dd6b5831ab43b5265"/>
 </manifest>

--- a/juno_stable.xml
+++ b/juno_stable.xml
@@ -7,17 +7,17 @@
   <remote fetch="https://github.com/OP-TEE" name="optee"/>
   <remote fetch="git://git.denx.de" name="u-boot"/>
   <default remote="optee" revision="master"/>
-  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="69fb412f18ee40f9f7707da0d7411aada5ab60a0" upstream="optee_paged_armtf_v1.2"/>
+  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="0d6e84bc2c68de1602de6fbadeae109eb8298c18"/>
   <project name="arm/vexpress-firmware.git" path="vexpress-firmware" remote="linaro" revision="cad383a2c4ffeb9192605fda54c07fd1aa09a1b0"/>
-  <project name="build.git" path="build" revision="refs/tags/2.3.0" upstream="master">
+  <project name="build.git" path="build" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="juno.mk"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="18f93163b1b7d598720a0c2fd23a76d4c4a8b6ac" upstream="optee"/>
-  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="u-boot.git" path="u-boot" remote="u-boot" revision="035ebf85b09cf11c820ae9eec414097420741abd" upstream="master"/>
+  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="961993fde60ebd06715d1433f8eb265471a0f38c"/>
+  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.4.0"/>
+  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.4.0"/>
+  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.4.0"/>
+  <project name="u-boot.git" path="u-boot" remote="u-boot" revision="d53ecad92f06d2e38a5cbc13af7473867c7fa277"/>
 </manifest>

--- a/mt8173-evb_stable.xml
+++ b/mt8173-evb_stable.xml
@@ -4,17 +4,17 @@
   <remote fetch="https://github.com/linaro-swg" name="linaro-swg"/>
   <remote fetch="https://github.com/OP-TEE" name="optee"/>
   <default remote="optee" revision="master"/>
-  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="063ff44a6af290ebb2fbea10222778b86bad9ed6" upstream="mt8173_evb"/>
-  <project name="build.git" path="build" revision="refs/tags/2.3.0" upstream="master">
+  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="8b2410cd5ab9189337379a9449c0f5588ae9b4a6"/>
+  <project name="build.git" path="build" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="mediatek.mk"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="evb-utils.git" path="evb-utils" remote="linaro-swg" revision="1127dbcdc76e45871ddb9f40f59ff684f6b85a20"/>
-  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="18f93163b1b7d598720a0c2fd23a76d4c4a8b6ac" upstream="optee"/>
-  <project name="mtk_tools.git" path="mtk_tools" remote="linaro-swg" revision="1460d821a19c7c81520605801026747e6be0e20e" upstream="master"/>
-  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.3.0" upstream="master"/>
+  <project name="evb-utils.git" path="evb-utils" remote="linaro-swg" revision="5494df3c6881739ff2faff636379aaef569c0281"/>
+  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="961993fde60ebd06715d1433f8eb265471a0f38c"/>
+  <project name="mtk_tools.git" path="mtk_tools" remote="linaro-swg" revision="1460d821a19c7c81520605801026747e6be0e20e"/>
+  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.4.0"/>
+  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.4.0"/>
+  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.4.0"/>
 </manifest>

--- a/qemu_v8_stable.xml
+++ b/qemu_v8_stable.xml
@@ -2,23 +2,26 @@
 <manifest>
   <remote fetch="git://busybox.net" name="busybox"/>
   <remote fetch="https://github.com/linaro-swg" name="linaro-swg"/>
+  <remote fetch="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds" name="linux"/>
   <remote fetch="https://github.com/OP-TEE" name="optee"/>
   <remote fetch="https://github.com/qemu" name="qemu"/>
   <remote fetch="http://git.code.sf.net/p/strace" name="sfnet"/>
+  <remote fetch="https://github.com/tianocore" name="tianocore"/>
   <default remote="optee" revision="master"/>
-  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="b3a3dde456445d294d83b18faf2769f6aa14ab48" upstream="refs/heads/optee_v2.1.0_paged_armtf_v1.2"/>
-  <project name="build.git" path="build" revision="refs/tags/2.3.0" upstream="master">
+  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="3fe1df3a038b0d69ea7c5c1de581ee6e1db28872"/>
+  <project name="build.git" path="build" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="qemu_v8.mk"/>
     <linkfile dest="build/gdb" src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="code" path="strace" remote="sfnet" revision="ca2bf7c9e9b7f1b82a77d400ca9691806f1cbfc8" upstream="master"/>
-  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="18f93163b1b7d598720a0c2fd23a76d4c4a8b6ac" upstream="optee"/>
-  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="qemu.git" path="qemu" remote="qemu" revision="a8c611e1133f97c979922f41103f79309339dc27" upstream="master"/>
-  <project name="soc_term.git" path="soc_term" remote="linaro-swg" revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" upstream="master"/>
+  <project name="code" path="strace" remote="sfnet" revision="7f6f12a829c8f3ba2b8bd5d821e3f34ab197bccb"/>
+  <project name="edk2.git" path="edk2" remote="tianocore" revision="c137d95081690d4877fbeb5f1856972e84ac32f2"/>
+  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="961993fde60ebd06715d1433f8eb265471a0f38c"/>
+  <project name="optee_client.git" path="optee_client" revision="refs/tags/2.4.0"/>
+  <project name="optee_os.git" path="optee_os" revision="refs/tags/2.4.0"/>
+  <project name="optee_test.git" path="optee_test" revision="refs/tags/2.4.0"/>
+  <project name="qemu.git" path="qemu" remote="qemu" revision="5fe2339e6b09da7d6f48b9bef0f1a7360392b489"/>
+  <project name="soc_term.git" path="soc_term" remote="linaro-swg" revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20"/>
 </manifest>

--- a/rpi3_stable.xml
+++ b/rpi3_stable.xml
@@ -3,18 +3,18 @@
   <remote fetch="https://github.com/mirror" name="busybox_mirror"/>
   <remote fetch="https://github.com/linaro-swg" name="linaro-swg"/>
   <remote fetch="https://github.com/OP-TEE" name="optee"/>
-  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="ec4262bbeba3c7db609fb2aa77a4ddc6deeeab5f" upstream="rpi3_initial_drop"/>
-  <project name="build.git" path="build" remote="optee" revision="refs/tags/2.3.0" upstream="master">
+  <project name="arm-trusted-firmware.git" path="arm-trusted-firmware" remote="linaro-swg" revision="1da4e15529a32fa244f5e3effc9a90549beb1a26"/>
+  <project name="build.git" path="build" remote="optee" revision="refs/tags/2.4.0">
     <linkfile dest="build/Makefile" src="rpi3.mk"/>
     <linkfile dest="build/pi3.cfg" src="rpi3/debugger/pi3.cfg"/>
     <linkfile dest="build/gdb" src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox_mirror" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="6173deadc2c552265633cca608b09adc0b0e33ec" upstream="master"/>
-  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a17da737d15438ebedf400255570afb5afe9454f" upstream="master"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="9f38d0f9d4aa32c8c2802be600d002eea222f9d1" upstream="electron752-rpi3-optee"/>
-  <project name="optee_client.git" path="optee_client" remote="optee" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_os.git" path="optee_os" remote="optee" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="optee_test.git" path="optee_test" remote="optee" revision="refs/tags/2.3.0" upstream="master"/>
-  <project name="u-boot.git" path="u-boot" remote="linaro-swg" revision="10577db76e77a513180388df1f176a6642143c84" upstream="rpi3_initial_drop"/>
+  <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="0e47dfb1a1dd72c06b9ceed4fd68bf7665e7ce6d"/>
+  <project name="hello_world.git" path="hello_world" remote="linaro-swg" revision="a2c215b7ddd880cce8fca7913e817f47460bdd40"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="9f38d0f9d4aa32c8c2802be600d002eea222f9d1"/>
+  <project name="optee_client.git" path="optee_client" remote="optee" revision="refs/tags/2.4.0"/>
+  <project name="optee_os.git" path="optee_os" remote="optee" revision="refs/tags/2.4.0"/>
+  <project name="optee_test.git" path="optee_test" remote="optee" revision="refs/tags/2.4.0"/>
+  <project name="u-boot.git" path="u-boot" remote="linaro-swg" revision="10577db76e77a513180388df1f176a6642143c84"/>
 </manifest>


### PR DESCRIPTION
So, I've tagged all the gits and I've updated all manifests (which this PR is about). I've added a second patch here on top that makes it possible to let Travis test manifest files. The changes in this PR seems to be OK, all builds [passed](https://travis-ci.org/jbech-linaro/manifest/jobs/219745438) after applying and using the 2.4.0 tag.

As you can see all "upstream" sections has been removed, this is something Pascal started removing on some projects and even though it's useful it's just a pain to maintain it. Instead people can use `$ git branch -a --contains <git>` instead if they want to know where the commit comes from.