### PR TITLE
hikey: change grub default branch

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -36,7 +36,7 @@
 	<project remote="96boards" path="edk2" name="edk2" revision="hikey" />
 
 	<!-- grub -->
-	<project remote="savannah" path="grub" name="grub" />
+	<project remote="savannah" path="grub" name="grub" revision="refs/tags/2.02"/>
 
 	<!-- Linux kernel -->
 	<project remote="linaro-swg" path="linux" name="linux" revision="optee"/>

--- a/hikey_debian.xml
+++ b/hikey_debian.xml
@@ -32,7 +32,7 @@
 	<project remote="96boards" path="edk2" name="edk2" revision="hikey" />
 
 	<!-- grub -->
-	<project remote="savannah" path="grub" name="grub" />
+	<project remote="savannah" path="grub" name="grub" revision="refs/tags/2.02"/>
 
 	<!-- Linux kernel -->
 	<project remote="linaro-swg" path="linux" name="linux" revision="optee"/>


### PR DESCRIPTION
Change grub default branch from master to the last stable (2.02 tag)
Fixes: https://github.com/OP-TEE/build/issues/144

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`