### PR TITLE
travis: Always use branch from the originator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,16 @@ script:
   # in the makefile.
   - if [ $REPO_PROJ == "fvp" ]; then mkdir -p $HOME/$REPO_PROJ/Foundation_Platformpkg; fi
   # Use the manifest from the branch itself we're pushing to.
-  - echo "Getting ${REPO_PROJ}_stable.xml from https://github.com/$TRAVIS_REPO_SLUG using branch $TRAVIS_BRANCH"
-  - cd $HOME/$REPO_PROJ && repo init -u https://github.com/$TRAVIS_REPO_SLUG -b $TRAVIS_BRANCH -m ${REPO_PROJ}_stable.xml </dev/null && repo sync -j2 --no-clone-bundle --no-tags --quiet
+  - |
+        if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
+                slug=$TRAVIS_PULL_REQUEST_SLUG
+                branch=$TRAVIS_PULL_REQUEST_BRANCH
+        else
+                slug=$TRAVIS_REPO_SLUG
+                branch=$TRAVIS_BRANCH
+        fi
+        echo "Getting ${REPO_PROJ}_stable.xml from https://github.com/$slug using branch $branch"
+        cd $HOME/$REPO_PROJ && repo init -u https://github.com/$slug -b $branch -m ${REPO_PROJ}_stable.xml </dev/null && repo sync -j2 --no-clone-bundle --no-tags --quiet
   # Fetch a local copy of dtc+libfdt to avoid issues with a possibly outdated libfdt-dev
   - if [ $REPO_PROJ == "qemu_v8" ]; then cd $HOME/$REPO_PROJ/qemu && git submodule update --init dtc; fi
   # Dump the content of the manifest (for debug purpose)


### PR DESCRIPTION
Force Travis to always use the branch from the originator, which means
that for both plain push and for pull requests it will use the
commiters own repository and commiters working branch.

I've tried this locally first and for that I created a local pull request also:
The PR passed: https://travis-ci.org/jbech-linaro/manifest/builds/238043712
The push itself passed: https://travis-ci.org/jbech-linaro/manifest/builds/238043694
And after merging ... it built the master, which also passed: https://travis-ci.org/jbech-linaro/manifest/builds/238219500

Hopefully this should solve our outstanding issues (and after this I plan to make the same change to build.git).

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>