### PR TITLE
qemu_v8: clone DTC source

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -30,6 +30,7 @@
 
 	<!-- QEMU -->
 	<project remote="qemu" path="qemu" name="qemu.git" />
+	<project remote="qemu" path="qemu/dtc" name="dtc.git" />
 
 	<!-- We're using Linaro SWG for ARM-TF until merged officially -->
 	<project remote="linaro-swg" path="arm-trusted-firmware" name="arm-trusted-firmware.git" revision="refs/heads/optee_v2.1.0_paged_armtf_v1.2" />


### PR DESCRIPTION
Ubuntu 1.4.04 LTS, 16.04 LTS and even 17.04 provide the libfdt in
version 1.4.0. This version is too old for the latest QEMU that
requires libfdt in version 1.4.2 or higher.

This change updates qemu_v8.xml so that the qemu/dtc/ source code is
cloned locally and therefore the build does not depend on libfdt.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>