### PR TITLE
QEMU v7/v8: Use a known working revision

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -28,7 +28,8 @@
 	<project remote="linaro-swg" path="optee_benchmark" name="optee_benchmark.git"/>
 
 	<!-- Temporary use the defined commit since upstream tip didn't work -->
-	<project remote="qemu" path="qemu" name="qemu.git" revision="c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064" />
+	<project remote="qemu" path="qemu" name="qemu.git" revision="199e19ee538eb61fd08b1c1ee5aa838ebdcc968e" />
+	<project remote="qemu" path="qemu/dtc" name="dtc.git" />
 
 	<!-- Build -->
 	<project remote="optee" path="build" name="build.git">

--- a/default_stable.xml
+++ b/default_stable.xml
@@ -17,6 +17,7 @@
   <project name="optee_client.git" path="optee_client" revision="refs/tags/2.5.0-rc1"/>
   <project name="optee_os.git" path="optee_os" revision="refs/tags/2.5.0-rc1"/>
   <project name="optee_test.git" path="optee_test" revision="refs/tags/2.5.0-rc1"/>
-  <project name="qemu.git" path="qemu" remote="qemu" revision="c5d128ffeb5357df1ea3e6de0c13b3d6a09f6064"/>
+  <project name="qemu.git" path="qemu" remote="qemu" revision="199e19ee538eb61fd08b1c1ee5aa838ebdcc968e"/>
+  <project name="dtc.git" path="qemu/dtc" remote="qemu" revision="558cd81bdd432769b59bff01240c44f82cfb1a9d"/>
   <project name="soc_term.git" path="soc_term" remote="linaro-swg" revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20"/>
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -29,7 +29,7 @@
 	<project remote="linaro-swg" path="soc_term" name="soc_term.git" />
 
 	<!-- QEMU -->
-	<project remote="qemu" path="qemu" name="qemu.git" />
+	<project remote="qemu" path="qemu" name="qemu.git" revision="199e19ee538eb61fd08b1c1ee5aa838ebdcc968e" />
 	<project remote="qemu" path="qemu/dtc" name="dtc.git" />
 
 	<!-- We're using Linaro SWG for ARM-TF until merged officially -->

--- a/qemu_v8_stable.xml
+++ b/qemu_v8_stable.xml
@@ -22,6 +22,7 @@
   <project name="optee_client.git" path="optee_client" revision="refs/tags/2.5.0-rc1"/>
   <project name="optee_os.git" path="optee_os" revision="refs/tags/2.5.0-rc1"/>
   <project name="optee_test.git" path="optee_test" revision="refs/tags/2.5.0-rc1"/>
-  <project name="qemu.git" path="qemu" remote="qemu" revision="577caa2672ccde7352fda3ef17e44993de862f0e"/>
+  <project name="qemu.git" path="qemu" remote="qemu" revision="199e19ee538eb61fd08b1c1ee5aa838ebdcc968e"/>
+  <project name="dtc.git" path="qemu/dtc" remote="qemu" revision="558cd81bdd432769b59bff01240c44f82cfb1a9d"/>
   <project name="soc_term.git" path="soc_term" remote="linaro-swg" revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20"/>
 </manifest>


### PR DESCRIPTION
For the 2.5.0 release we found some regressions when running latest on
QEMU. After bisecting we managed to find where the issues where
introduced, they are as follows:

  v8: (e75449a346) target/aarch64: optimize indirect branches
  v7: (8a6b28c7b5) target/arm: optimize indirect branches

There is a fix for that upstream, but apparently that fix does not solve
the problems for TrustZone and therefore we need more time to
investigate it. Because of that we decided to temporarily use the
previous merge commit in QEMU that is working fine on both v7 and v8 and
that is:
  (199e19e) Merge remote-tracking branch 'remotes/mjt/tags/trivial-patches-fetch' into staging

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>