### PR TITLE
qemu_v8.xml: pin EDK2 version

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -36,7 +36,8 @@
 	<project remote="linaro-swg" path="arm-trusted-firmware" name="arm-trusted-firmware.git" revision="refs/heads/optee_v2.1.0_paged_armtf_v1.2" />
 
         <!-- Tianocore, EDK2 -->
-        <project remote="tianocore" path="edk2" name="edk2.git" />
+	<!-- Pinned revision because master is currently broken -->
+	<project remote="tianocore" path="edk2" name="edk2.git" revision="f7bd152c2a05bd75471305184c25f14f01ccf0b7" />
 
 	<!-- strace -->
 	<project remote="sfnet" path="strace" name="code" />


### PR DESCRIPTION
Do not use the EDK2 master branch because it is currently broken:

 Building ... /home/jerome/work/optee_repo_qemu_v8/edk2/MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf [AARCH64]
 Segmentation fault (core dumped)
 GNUmakefile:365: recipe for target '/home/jerome/work/optee_repo_qemu_v8/edk2/Build/ArmVirtQemuKernel-AARCH64/DEBUG_GCC49/AARCH64/MdeModulePkg/Universal/SerialDxe/SerialDxe/DEBUG/SerialDxe.efi' failed
 make[2]: *** [/home/jerome/work/optee_repo_qemu_v8/edk2/Build/ArmVirtQemuKernel-AARCH64/DEBUG_GCC49/AARCH64/MdeModulePkg/Universal/SerialDxe/SerialDxe/DEBUG/SerialDxe.efi] Error 139
 make[2]: Leaving directory '/home/jerome/work/optee_repo_qemu_v8/edk2/Build/ArmVirtQemuKernel-AARCH64/DEBUG_GCC49/AARCH64/MdeModulePkg/Universal/SerialDxe/SerialDxe'

Instead, use the last known good commit: f7bd152c2a05 ("BaseTools:
Update tools_def.template").

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Suggested-by: Etienne Carriere <etienne.carriere@linaro.org>