### PR TITLE
Pin tools-images-hikey960

### DIFF
--- a/hikey960.xml
+++ b/hikey960.xml
@@ -18,7 +18,7 @@
 	<project remote="96b-hk" path="l-loader" name="l-loader" revision="testing/hikey960_v1.2" />
 
 	<!-- tools -->
-	<project remote="96b-hk" path="tools-images-hikey960" name="tools-images-hikey960" />
+	<project remote="96b-hk" path="tools-images-hikey960" name="tools-images-hikey960" revision="ccb401f726346355e948ec776a411ad037bab4cc" />
 
 	<!-- OP-TEE gits -->
 	<project path="optee_os" name="optee_os" />


### PR DESCRIPTION
With 92f365073cd8 ("lpm3, xloader: fix spi2 and i2c0 clock slow issue")
in tools-images-hikey960, the board won't boot. The kernel hangs at:

[0.753291] hi3660-mbox e896b000.mailbox: Mailbox enabled
[ 21.773459] INFO: rcu_preempt detected stalls on CPUs/tasks:
[ 21.779191] 5-...: (1 GPs behind) idle=135/140000000000000/0 softirq=21/22 fqs=2625
[ 21.787109] (detected by 0, t=5252 jiffies, g=-289, c=-290, q=111)
[ 21.793448] Task dump for CPU 5:
[ 21.796706] swapper/0 R running task 0 1 0 0x00000002
[ 21.803837] Call trace:
[ 21.806320] [] __switch_to+0x94/0xa8
[ 21.811513] [<0000000000000040>] 0x40

Work around this issue by pinning the parent commit in hikey960.xml.

Fixes: https://github.com/OP-TEE/optee_os/issues/1851
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>