### PR TITLE
qemu_v8.xml: pin arm-trusted-firmware revision

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -36,7 +36,7 @@
 	<project remote="qemu" path="qemu" name="qemu.git" revision="199e19ee538eb61fd08b1c1ee5aa838ebdcc968e" />
 	<project remote="qemu" path="qemu/dtc" name="dtc.git" />
 
-	<project remote="arm" path="arm-trusted-firmware" name="arm-trusted-firmware.git" />
+	<project remote="arm" path="arm-trusted-firmware" name="arm-trusted-firmware.git" revision="d55a445069736e2652b44ddfeb9ea4d306796a0a" />
 
         <!-- Tianocore, EDK2 -->
 	<!-- Pinned revision because master is currently broken -->


### PR DESCRIPTION
Pin arm-trusted-firmware revision to avoid the follwowing build error
with current master:

 plat/qemu/qemu_bl31_setup.c:129:2: error: unknown field 'g0_interrupt_num' specified in initializer
   .g0_interrupt_num = ARRAY_SIZE(irq_sec_array),
   ^

Error was bisected to:

 22966106967b01768db5140ce20f62dd7f20358f is the first bad commit
 commit 22966106967b01768db5140ce20f62dd7f20358f
 Author: Jeenu Viswambharan <jeenu.viswambharan@arm.com>
 Date:   Fri Sep 22 08:32:09 2017 +0100

     GIC: Add helpers to set interrupt configuration

     The helpers perform read-modify-write on GIC*_ICFGR registers, but don't
     serialise callers. Any serialisation must be taken care of by the
     callers.

     Change-Id: I71995f82ff2c7f70d37af0ede30d6ee18682fd3f
     Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>