### PR TITLE
Revert "Pin tools-images-hikey960"

### DIFF
--- a/hikey960.xml
+++ b/hikey960.xml
@@ -18,7 +18,7 @@
 	<project remote="96b-hk" path="l-loader" name="l-loader" revision="testing/hikey960_v1.2" />
 
 	<!-- tools -->
-	<project remote="96b-hk" path="tools-images-hikey960" name="tools-images-hikey960" revision="ccb401f726346355e948ec776a411ad037bab4cc" />
+	<project remote="96b-hk" path="tools-images-hikey960" name="tools-images-hikey960" />
 
 	<!-- OP-TEE gits -->
 	<project path="optee_os" name="optee_os" />


### PR DESCRIPTION
This reverts commit 64873598f9f5d76769b01f333a8f882011750211.

Fixed in https://github.com/96boards-hikey/OpenPlatformPkg/pull/61.

Signed-off-by: Victor Chong <victor.chong@linaro.org>