### PR TITLE
Add grub to the FVP manifest

### DIFF
--- a/fvp.xml
+++ b/fvp.xml
@@ -4,7 +4,7 @@
 	<remote name="busybox" fetch="git://busybox.net" />
 	<remote name="linaro-swg" fetch="https://github.com/linaro-swg" />
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
-	<remote name="landing-teams" fetch="https://git.linaro.org/landing-teams" />
+	<remote name="tianocore" fetch="https://github.com/tianocore" />
 	<remote name="savannah" fetch="https://git.savannah.gnu.org/git" />
 
 	<default remote="optee" revision="master" />
@@ -21,7 +21,8 @@
 	<project remote="arm" path="arm-trusted-firmware" name="arm-trusted-firmware.git" />
 
 	<!-- Tianocore, EDK2 -->
-	<project remote="landing-teams" path="edk2" name="working/arm/edk2.git" revision="16.01" />
+	<project remote="tianocore" path="edk2" name="edk2.git" />
+	<project remote="tianocore" path="edk2-platforms" name="edk2-platforms.git" />
 
 	<!-- Linux kernel -->
 	<project remote="linaro-swg" path="linux" name="linux.git" revision="optee"/>

--- a/fvp.xml
+++ b/fvp.xml
@@ -5,6 +5,7 @@
 	<remote name="linaro-swg" fetch="https://github.com/linaro-swg" />
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
 	<remote name="landing-teams" fetch="https://git.linaro.org/landing-teams" />
+	<remote name="savannah" fetch="https://git.savannah.gnu.org/git" />
 
 	<default remote="optee" revision="master" />
 
@@ -30,6 +31,9 @@
 
 	<!-- Filesystem -->
 	<project remote="linaro-swg" path="gen_rootfs" name="gen_rootfs.git" />
+
+	<!-- Grub -->
+	<project remote="savannah" path="grub" name="grub.git" />
 
 	<!-- Build -->
 	<project path="build" name="build.git">


### PR DESCRIPTION
This is a first step in updating EDK2 on FVP. The new way of doing this will include grub. So we can merge this as a standalone patch and later patches would not need to be merged at the "same" time as this patch.

**EDIT** : Actually I need to push more patches to `manifest.git`, i.e., one for updating `ekd2`, so there will still be patches that are dependant on each other and would need to be merged at the same time. So, the comment above doesn't make that much sense due to that.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>