### PR TITLE
qemu v8: Use edk2-platforms

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -39,8 +39,8 @@
 	<project remote="arm" path="arm-trusted-firmware" name="arm-trusted-firmware.git" />
 
         <!-- Tianocore, EDK2 -->
-	<!-- Pinned revision because master is currently broken -->
-	<project remote="tianocore" path="edk2" name="edk2.git" revision="f7bd152c2a05bd75471305184c25f14f01ccf0b7" />
+	<project remote="tianocore" path="edk2" name="edk2.git" />
+	<project remote="tianocore" path="edk2-platforms" name="edk2-platforms.git" />
 
 	<!-- strace -->
 	<project remote="sfnet" path="strace" name="code" />


### PR DESCRIPTION
The recent changes in [build.git](https://github.com/OP-TEE/build/commit/ab6226112e48979ab6a20dec09e978d34a793329) also affects QEMU v8. Therefore we need edk2-platforms in that setup also.