### PR TITLE
Fix bad Linux kernel commit

### DIFF
--- a/default_stable.xml
+++ b/default_stable.xml
@@ -12,7 +12,7 @@
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
   <project name="dtc.git" path="qemu/dtc" remote="qemu" revision="c1e55a5513e9bca41dc78a0f20245cc928596a3a"/>
   <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="fe617d470e45778c909038bf3e7ca15174a4f893"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="50403184d40d04b3daf140417e031c16c2985eaf"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="6e954e2f2cbd412f7bc874bb9145f69713194e52"/>
   <project name="optee_benchmark.git" path="optee_benchmark" remote="linaro-swg" revision="refs/tags/2.6.0"/>
   <project name="optee_client.git" path="optee_client" revision="refs/tags/2.6.0"/>
   <project name="optee_examples.git" path="optee_examples" remote="linaro-swg" revision="refs/tags/2.6.0"/>

--- a/fvp_stable.xml
+++ b/fvp_stable.xml
@@ -12,7 +12,7 @@
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
   <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="fe617d470e45778c909038bf3e7ca15174a4f893"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="50403184d40d04b3daf140417e031c16c2985eaf"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="6e954e2f2cbd412f7bc874bb9145f69713194e52"/>
   <project name="optee_client.git" path="optee_client" revision="refs/tags/2.6.0"/>
   <project name="optee_examples.git" path="optee_examples" remote="linaro-swg" revision="refs/tags/2.6.0"/>
   <project name="optee_os.git" path="optee_os" revision="refs/tags/2.6.0"/>

--- a/hikey_stable.xml
+++ b/hikey_stable.xml
@@ -21,7 +21,7 @@
   <project name="gen_rootfs" remote="linaro-swg" revision="fe617d470e45778c909038bf3e7ca15174a4f893"/>
   <project name="grub" remote="savannah" revision="e54c99aaff5e5f6f5d3b06028506c57e66d8ef77"/>
   <project name="l-loader" remote="96b-hk" revision="8f9ac6cca2787a5a683989bdd96f6dcd4629a30a"/>
-  <project name="linux" remote="linaro-swg" revision="50403184d40d04b3daf140417e031c16c2985eaf"/>
+  <project name="linux" remote="linaro-swg" revision="6e954e2f2cbd412f7bc874bb9145f69713194e52"/>
   <project name="optee_client" revision="refs/tags/2.6.0"/>
   <project name="optee_examples.git" path="optee_examples" remote="linaro-swg" revision="refs/tags/2.6.0"/>
   <project name="optee_os" revision="refs/tags/2.6.0"/>

--- a/juno_stable.xml
+++ b/juno_stable.xml
@@ -14,7 +14,7 @@
   </project>
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
   <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="fe617d470e45778c909038bf3e7ca15174a4f893"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="50403184d40d04b3daf140417e031c16c2985eaf"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="6e954e2f2cbd412f7bc874bb9145f69713194e52"/>
   <project name="optee_client.git" path="optee_client" revision="refs/tags/2.6.0"/>
   <project name="optee_examples.git" path="optee_examples" remote="linaro-swg" revision="refs/tags/2.6.0"/>
   <project name="optee_os.git" path="optee_os" revision="refs/tags/2.6.0"/>

--- a/mt8173-evb_stable.xml
+++ b/mt8173-evb_stable.xml
@@ -11,7 +11,7 @@
   <project name="busybox.git" path="busybox" remote="busybox" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
   <project name="evb-utils.git" path="evb-utils" remote="linaro-swg" revision="5494df3c6881739ff2faff636379aaef569c0281"/>
   <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="fe617d470e45778c909038bf3e7ca15174a4f893"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="50403184d40d04b3daf140417e031c16c2985eaf"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="6e954e2f2cbd412f7bc874bb9145f69713194e52"/>
   <project name="mtk_tools.git" path="mtk_tools" remote="linaro-swg" revision="1460d821a19c7c81520605801026747e6be0e20e"/>
   <project name="optee_client.git" path="optee_client" revision="refs/tags/2.6.0"/>
   <project name="optee_examples.git" path="optee_examples" remote="linaro-swg" revision="refs/tags/2.6.0"/>

--- a/qemu_v8_stable.xml
+++ b/qemu_v8_stable.xml
@@ -19,7 +19,7 @@
   <project name="dtc.git" path="qemu/dtc" remote="qemu" revision="c1e55a5513e9bca41dc78a0f20245cc928596a3a"/>
   <project name="edk2.git" path="edk2" remote="tianocore" revision="f7bd152c2a05bd75471305184c25f14f01ccf0b7"/>
   <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="fe617d470e45778c909038bf3e7ca15174a4f893"/>
-  <project name="linux.git" path="linux" remote="linaro-swg" revision="50403184d40d04b3daf140417e031c16c2985eaf"/>
+  <project name="linux.git" path="linux" remote="linaro-swg" revision="6e954e2f2cbd412f7bc874bb9145f69713194e52"/>
   <project name="optee_benchmark.git" path="optee_benchmark" remote="linaro-swg" revision="refs/tags/2.6.0"/>
   <project name="optee_client.git" path="optee_client" revision="refs/tags/2.6.0"/>
   <project name="optee_examples.git" path="optee_examples" remote="linaro-swg" revision="refs/tags/2.6.0"/>


### PR DESCRIPTION
Due to linaro-swg/linux optee branch being overwritten to fix an error
in it's history, the existing commit cannot be checkout out anymore, so
replace it with the corresponding one in the branch that overwrote it.

Signed-off-by: Victor Chong <victor.chong@linaro.org>