### PR TITLE
rpi3: change firmware remote revision back to tag

### DIFF
--- a/rpi3_stable.xml
+++ b/rpi3_stable.xml
@@ -12,7 +12,7 @@
     <linkfile dest="build/gdb" src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb"/>
   </project>
   <project name="busybox.git" path="busybox" remote="busybox_mirror" revision="dbf5a6da6a4295ce26edd1ce34fde567d19afa02"/>
-  <project clone-depth="1" name="firmware.git" path="firmware" remote="raspberrypi" revision="3fb63c413cabfddb7fb9ed286bfc62abe73cc310"/>
+  <project clone-depth="1" name="firmware.git" path="firmware" remote="raspberrypi" revision="refs/tags/1.20170215"/>
   <project name="gen_rootfs.git" path="gen_rootfs" remote="linaro-swg" revision="fe617d470e45778c909038bf3e7ca15174a4f893"/>
   <project name="linux.git" path="linux" remote="linaro-swg" revision="7d976fc52ae3f04618062967948e626166f1904a"/>
   <project name="optee_benchmark.git" path="optee_benchmark" remote="linaro-swg" revision="refs/tags/2.6.0"/>


### PR DESCRIPTION
SHA-1 hashes can't be used mutually with clone-depth="1".
Although since Git version 2.5 servers may expose raw hashes,
it's common practice to disable this feature (it's
server-side configuration item) because of security flaws.

Fixes: https://github.com/OP-TEE/manifest/issues/88

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`
  