### PR TITLE
Switch to GitHub for strace

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -6,12 +6,12 @@
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
 	<remote name="savannah" fetch="git://git.savannah.gnu.org" />
 	<remote name="96b-hk" fetch="https://github.com/96boards-hikey" />
-	<remote name="sfnet" fetch="git://git.code.sf.net/p/strace" />
+	<remote name="strace" fetch="https://github.com/strace" />
 
 	<default remote="optee" revision="master" />
 
 	<!-- strace -->
-	<project remote="sfnet" path="strace" name="code" />
+	<project remote="strace" path="strace" name="strace" />
 
 	<!-- l-loader -->
 	<project remote="96b-hk" path="l-loader" name="l-loader" revision="testing/hikey960_v1.2" />

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -7,12 +7,12 @@
 	<remote name="savannah" fetch="git://git.savannah.gnu.org" />
 	<remote name="96boards" fetch="https://github.com/96boards" />
 	<remote name="96b-hk" fetch="https://github.com/96boards-hikey" />
-	<remote name="sfnet" fetch="git://git.code.sf.net/p/strace" />
+	<remote name="strace" fetch="https://github.com/strace" />
 
 	<default remote="optee" revision="master" />
 
 	<!-- strace -->
-	<project remote="sfnet" path="strace" name="code" />
+	<project remote="strace" path="strace" name="strace" />
 
 	<!-- l-loader -->
 	<project remote="96b-hk" path="l-loader" name="l-loader" revision="testing/hikey960_v1.2" />

--- a/hikey_debian.xml
+++ b/hikey_debian.xml
@@ -7,12 +7,12 @@
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
 	<remote name="savannah" fetch="git://git.savannah.gnu.org" />
 	<remote name="96b-hk" fetch="https://github.com/96boards-hikey" />
-	<remote name="sfnet" fetch="git://git.code.sf.net/p/strace" />
+	<remote name="strace" fetch="https://github.com/strace" />
 
 	<default remote="optee" revision="master" />
 
 	<!-- strace -->
-	<project remote="sfnet" path="strace" name="code" />
+	<project remote="strace" path="strace" name="strace" />
 
 	<!-- l-loader -->
 	<project remote="96b-hk" path="l-loader" name="l-loader" revision="testing/hikey960_v1.2" />

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -7,7 +7,7 @@
 	<remote name="optee" fetch="https://github.com/OP-TEE" />
         <remote name="tianocore" fetch="https://github.com/tianocore" />
 	<remote name="qemu" fetch="https://github.com/qemu" />
-	<remote name="sfnet" fetch="http://git.code.sf.net/p/strace" />
+	<remote name="strace" fetch="https://github.com/strace" />
 
 	<default remote="optee" revision="master" />
 
@@ -43,7 +43,7 @@
 	<project remote="tianocore" path="edk2-platforms" name="edk2-platforms.git" />
 
 	<!-- strace -->
-	<project remote="sfnet" path="strace" name="code" />
+	<project remote="strace" path="strace" name="strace" />
 
 	<!-- Build -->
 	<project remote="optee" path="build" name="build.git">


### PR DESCRIPTION
SourceForge is unreliable [1]. Use GitHub instead.

Change-Id: I73241adf4a0ce9b0a8985914ee4523f1d46e9207
Link: [1] https://travis-ci.org/OP-TEE/build/jobs/342160257#L621-L629
Suggested-by: Joakim Bech <joakim.bech@linaro.org>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>