### PR TITLE
hikey: step up Arm-TF and atf-fastboot to match l-loader

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -20,8 +20,8 @@
         <project path="patches_hikey"        name="linaro-swg/patches_hikey.git"          revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v1.4" clone-depth="1" />
-        <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="0743e48eb793749cc801adbb63d3a9d27da4b1ec" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="02f8c03884d69c5915f07b82851f72fbacb448bd" />
+        <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="af5ddb16266e54745d3b2e354d32b54fefbbbd78" />
         <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="bee2ea1660f3a03df8d391fb75aa08dbc3441856" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="2d899728eda95d57f8e9d9bee6cc9b6eefe422b7" />


### PR DESCRIPTION
After pinning all git's but OP-TEE and at the same time introducing the new l-loader (using recovery.bin) we introduced a flash regression for HiKey. This also affected [HAB](https://github.com/jbech-linaro/hikey_auto_boot/tree/webserver_python3) which forced me to turn HAB off temporarily. The fix was pretty easy though. It turned out that we needed to step up both Arm-TF and atf-fastboot to make be in sync with l-loader.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>