### PR TITLE
Add helper script used for tagging releases

### DIFF
--- a/make_stable.sh
+++ b/make_stable.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+VERSION=
+OVERWRITE=false
+
+function help() {
+	echo "    -r <revision>  new revision for OP-TEE and linaro-swg gits"
+	echo "    -o             overwrite existing xml-files"
+	echo "    -h             help"
+	exit
+}
+
+while getopts "or:h" opt; do
+	case $opt in
+		o)
+			OVERWRITE=true
+			;;
+		r)
+			VERSION=${OPTARG}
+			;;
+		h)
+			help
+			;;
+		\?)
+			echo "Invalid option: -${OPTARG}" >&2
+			exit 1
+			;;
+		:)
+			echo "Option -${OPTARG} requires an argument." >&2
+			exit 1
+			;;
+	esac
+done
+
+if [ -z "${VERSION}" ]; then
+	echo "No version provided, not doing any changes!"
+	exit
+fi
+
+for xml in *.xml
+do
+	FILE=$xml.${VERSION}
+	if [ ${OVERWRITE} == true ]; then
+		FILE=$xml
+	fi
+
+	cat $xml | 
+		sed "s/\(OP-TEE\/.*\)revision.*/\1\/>/" | # Removes old revision
+		sed "s/\(OP-TEE.*\"\)/\1 revision=\"refs\/tags\/${VERSION}\" clone-depth=\"1\"/" |
+		sed "s/\(OP-TEE\/build.git.*\) \/>/\1>/" | # Strip away a forward slash from build.git only
+
+		sed "s/\(linaro-swg\/optee_examples.git\)revision.*/\1\/>/" | # Removes old revision
+		sed "s/\(linaro-swg\/optee_examples.git\"\)/\1 revision=\"refs\/tags\/${VERSION}\" clone-depth=\"1\"/" |
+		sed "s/\(linaro-swg\/optee_benchmark.git\)revision.*/\1\/>/" | # Removes old revision
+		sed "s/\(linaro-swg\/optee_benchmark.git\"\)/\1 revision=\"refs\/tags\/${VERSION}\" clone-depth=\"1\"/" |
+		tee ${FILE} 2>&1 > /dev/null
+done


### PR DESCRIPTION
This script will typically be used when we are about to release a new
OP-TEE version. The script will update all GitHub/OP-TEE gits likewise
it will also update all the gits we are hosting at GitHub/linaro-swg. It
will leave the "Misc" gits untouched.

If you want to see what it does, then simply just clone this git and run
```bash
$ ./make_stable.sh -o -r 3.1.0
```
Then run `git diff` and you will see the changes.

I know Jerome had a comment when I showed this at Connect about tagging in "linaro-swg" might interfere with existing tags (for example Linux kernel). It would be possible to tweak the script to prepend `optee_` for the gits in `github.com/linaro-swg` for example. In the end the tags there should never end up in the upstream project, it is just for our own sake, so I don't think it's a big deal as long as we can tell the difference between tags.

So how is this going to be used? At release time, one create a new branch in the manifest.git, run the script, commit and then push this branch. Then we are done. So something like this (for the coming `3.1.0` release).
```bash
$ cd <manifest.git>
$ git checkout -b 3.1.0 origin/master
$ ./make_stable.sh -o -r 3.1.0
$ git add -u
$ git commit -s -m "OP-TEE 3.1.0 stable"
$ git tag -a 3.1.0 -m "OP-TEE 3.1.0 stable"
```
Then later on when users need a stable version they run (`HiKey` as an example)
```bash
$ repo init -u https://github.com/OP-TEE/manifest.git -m hikey.xml -b 3.1.0
$ repo sync
```

And yes, the `sed` operations are hairy and scary and can probably be done in a much nicer way, but I see that as future improvements ;-)