### PR TITLE
default, qemu_v8, hikey: update linux snapshot..

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
 
         <!-- linaro-swg gits -->
         <project path="bios_qemu_tz_arm"   name="linaro-swg/bios_qemu_tz_arm.git" revision="0271acbfa81d93e64c2fdd6ae8b0be14a8c45719" />
-        <project path="linux"              name="linaro-swg/linux.git"            revision="6e954e2f2cbd412f7bc874bb9145f69713194e52" />
+        <project path="linux"              name="linaro-swg/linux.git"            revision="94c2f2e1cb08073cd688bd51638920b1cc6ad166" />
         <project path="optee_benchmark"    name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"     name="linaro-swg/optee_examples.git" />
         <project path="soc_term"           name="linaro-swg/soc_term.git"         revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />

--- a/hikey.xml
+++ b/hikey.xml
@@ -15,7 +15,7 @@
 
         <!-- linaro-swg gits -->
         <project path="gen_rootfs"           name="linaro-swg/gen_rootfs.git"             revision="d5429c154fb81fdae75886d505c385b2f0bb7153"/>
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="6e954e2f2cbd412f7bc874bb9145f69713194e52" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="94c2f2e1cb08073cd688bd51638920b1cc6ad166" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="patches_hikey"        name="linaro-swg/patches_hikey.git"          revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -15,7 +15,7 @@
 
         <!-- linaro-swg gits -->
         <project path="gen_rootfs"           name="linaro-swg/gen_rootfs.git"             revision="d5429c154fb81fdae75886d505c385b2f0bb7153" />
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="6e954e2f2cbd412f7bc874bb9145f69713194e52" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="94c2f2e1cb08073cd688bd51638920b1cc6ad166" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />


### PR DESCRIPTION
..to include 94c2f2e (""tee: fix unbalanced context refcount in register
shm from fd") bug fix for 9f9806e ("tee: new ioctl to a register tee_shm
from a dmabuf file descriptor")

Change-Id: Id0f7f356597a451d20de21657b75b35597c980a0
Signed-off-by: Victor Chong <victor.chong@linaro.org>
Tested-by: Victor Chong <victor.chong@linaro.org> (qemu, qemu_v8, hikey)