### PR TITLE
qemu: update bios_qemu_tz_arm

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="bios_qemu_tz_arm"   name="linaro-swg/bios_qemu_tz_arm.git" revision="0271acbfa81d93e64c2fdd6ae8b0be14a8c45719" />
+        <project path="bios_qemu_tz_arm"   name="linaro-swg/bios_qemu_tz_arm.git" revision="b099845f32cb424b0bbb72ba613aa6e85fc16326" />
         <project path="linux"              name="linaro-swg/linux.git"            revision="6e954e2f2cbd412f7bc874bb9145f69713194e52" />
         <project path="optee_benchmark"    name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"     name="linaro-swg/optee_examples.git" />


### PR DESCRIPTION
Since commit bdc2df1e704d ("qemu: discard legacy bios mailbox and
support arm-tf boot scheme"), OP-TEE OS needs a new version of
bios_qemu_tz_arm.

Change-Id: I90c056416939e78b0b26f834eb174945be0e51ed
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>