### PR TITLE
hikey960: update tools-images-hikey960

### DIFF
--- a/hikey960.xml
+++ b/hikey960.xml
@@ -27,5 +27,5 @@
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="fbdd4aeee4d8de04d1c332379b20efb7a59a9502" />
         <project path="strace"                name="strace/strace.git"                        revision="refs/tags/v4.21" clone-depth="1" />
-        <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="cf2ee0c6c1823d1a5b5a41942487054273b71813" />
+        <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />
 </manifest>


### PR DESCRIPTION
Commit f9f39124efd1 ("hikey*: support migration to BL2_EL3 on arm-tf")
in build.git has changed the name of nvme.img to hisi-nvme.img, to
reflect the latest name used in upstream tools-images-hikey960.git, after
commit b5ae2c13438e ("installer: add hisi- prefix to ptable, sec_xloader,
fastboot, sec_uce_boot, and sec_usb_xloader imgs").
Unfortunately the HiKey960 manifest still references an older version of
the project, which causes an error during "make flash":

 $ make flash
 [...]
 fastboot flash nvme /home/jerome/work/optee_repo_hikey960/build/../tools-images-hikey960/hisi-nvme.img
 error: cannot load '/home/jerome/work/optee_repo_hikey960/build/../tools-images-hikey960/hisi-nvme.img'
 Makefile:322: recipe for target 'flash' failed
 make: *** [flash] Error 1

Fix this by updating tools-images-hikey960 in hikey960.xml (use the
current tip of the master branch).

Change-Id: If918d95bebad72b9813704769180f0579c73fb2d
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>