### PR TITLE
qemu: add arm trusted firmware

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -5,22 +5,23 @@
         <default remote="github" revision="master" />
 
         <!-- OP-TEE gits -->
-        <project path="optee_client"       name="OP-TEE/optee_client.git" />
-        <project path="optee_os"           name="OP-TEE/optee_os.git" />
-        <project path="optee_test"         name="OP-TEE/optee_test.git" />
-        <project path="build"              name="OP-TEE/build.git">
+        <project path="optee_client"        name="OP-TEE/optee_client.git" />
+        <project path="optee_os"            name="OP-TEE/optee_os.git" />
+        <project path="optee_test"          name="OP-TEE/optee_test.git" />
+        <project path="build"               name="OP-TEE/build.git">
                 <linkfile src="qemu.mk" dest="build/Makefile" />
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="bios_qemu_tz_arm"   name="linaro-swg/bios_qemu_tz_arm.git" revision="b099845f32cb424b0bbb72ba613aa6e85fc16326" />
-        <project path="linux"              name="linaro-swg/linux.git"            revision="6e954e2f2cbd412f7bc874bb9145f69713194e52" />
-        <project path="optee_benchmark"    name="linaro-swg/optee_benchmark.git" />
-        <project path="optee_examples"     name="linaro-swg/optee_examples.git" />
-        <project path="soc_term"           name="linaro-swg/soc_term.git"         revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
+        <project path="bios_qemu_tz_arm"     name="linaro-swg/bios_qemu_tz_arm.git"       revision="b099845f32cb424b0bbb72ba613aa6e85fc16326" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="6e954e2f2cbd412f7bc874bb9145f69713194e52" />
+        <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
+        <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
+        <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
 
         <!-- Misc gits -->
-        <project path="buildroot"          name="buildroot/buildroot.git"         revision="refs/tags/2017.11" clone-depth="1" />
-        <project path="qemu/dtc"           name="qemu/dtc.git"                    revision="refs/tags/v1.4.6" clone-depth="1" />
-        <project path="qemu"               name="qemu/qemu.git"                   revision="refs/tags/v2.10.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v1.5" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2017.11" clone-depth="1" />
+        <project path="qemu/dtc"             name="qemu/dtc.git"                          revision="refs/tags/v1.4.6" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v2.10.0" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Arm trusted firmware can boot op-tee qemu cortex-a15 for the qemu_virt setup.
This change bring arm-trusted-firmware source tree.
Required by https://github.com/OP-TEE/build/pull/252.