### PR TITLE
Bumped buildroot and qemu

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,7 +21,7 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v1.5" clone-depth="1" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2017.11" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="62dca337fe72085d98b7603cfcff1279c48ba7d9" />
         <project path="qemu/dtc"             name="qemu/dtc.git"                          revision="refs/tags/v1.4.6" clone-depth="1" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v2.10.0" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v2.12.0" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
make fails on Ubuntu 18.04 due to problems with glibc 2.27.

Some other projects had this problem with e2fsprogs:
https://forum.lede-project.org/t/any-device-build-fail-e2fsprogs-debugfs/12433
https://github.com/openwrt/openwrt/pull/781

and QEMU:
https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1753826