### PR TITLE
Rpi3: build using Buildroot

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -17,7 +17,6 @@
         <!-- linaro-swg gits -->
                  <!-- ARM Trusted Firmware, cannot use refs/tags, since we need current tip and that is not tagged  -->
         <project path="arm-trusted-firmware" name="linaro-swg/arm-trusted-firmware.git" revision="1da4e15529a32fa244f5e3effc9a90549beb1a26"/>
-        <project path="gen_rootfs"           name="linaro-swg/gen_rootfs.git"           revision="d5429c154fb81fdae75886d505c385b2f0bb7153" />
         <project path="linux"                name="linaro-swg/linux.git"                revision="7d976fc52ae3f04618062967948e626166f1904a" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
@@ -25,6 +24,6 @@
         <project path="u-boot"               name="linaro-swg/u-boot.git"               revision="bc6d93cf5eee9fc979a7c5141ff6312bed2835a2"/>
 
         <!-- Misc gits -->
-        <project path="busybox"              name="mirror/busybox.git"                  revision="refs/tags/1_24_0" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"             revision="62dca337fe72085d98b7603cfcff1279c48ba7d9" />
         <project path="firmware"             name="raspberrypi/firmware.git"            revision="refs/tags/1.20170215" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Depends on https://github.com/OP-TEE/build/pull/268.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>