### PR TITLE
fvp, hikey, hikey960, poplar: step up buildroot

### DIFF
--- a/fvp.xml
+++ b/fvp.xml
@@ -22,5 +22,5 @@
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="c4122dcaadb964a3e5d2fe106939bca4f1c261e8" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="c76bf98bc8f988ea2f3953563f94fab8268ec3bd" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2017.11" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="62dca337fe72085d98b7603cfcff1279c48ba7d9" />
 </manifest>

--- a/hikey.xml
+++ b/hikey.xml
@@ -27,5 +27,5 @@
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="l-loader"             name="96boards-hikey/l-loader.git"           revision="c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc" />
         <project path="OpenPlatformPkg"      name="96boards-hikey/OpenPlatformPkg.git"    revision="fbdd4aeee4d8de04d1c332379b20efb7a59a9502" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2017.11" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="62dca337fe72085d98b7603cfcff1279c48ba7d9" />
 </manifest>

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -25,5 +25,5 @@
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="fbdd4aeee4d8de04d1c332379b20efb7a59a9502" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />
-        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2017.11" clone-depth="1" />
+        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="62dca337fe72085d98b7603cfcff1279c48ba7d9" />
 </manifest>

--- a/poplar.xml
+++ b/poplar.xml
@@ -23,5 +23,5 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git"/>
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2017.11" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="62dca337fe72085d98b7603cfcff1279c48ba7d9" />
 </manifest>


### PR DESCRIPTION
To avoid build errors on Ubuntu 18.04 step up buildroot to the same
version used by the other platforms.

Change-Id: I3ff11e5de466a465774e75fafd34e5d54707a886
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>