### PR TITLE
Update QEMU, QEMUv8, HiKey620, HiKey960, Juno and FVP to kernel v4.19

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
 
         <!-- linaro-swg gits -->
         <project path="u-boot"               name="linaro-swg/u-boot.git"                 revision="optee" />
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="75065d7a22b08115477ae75b42139c5336e28293" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />

--- a/fvp.xml
+++ b/fvp.xml
@@ -14,7 +14,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="75065d7a22b08115477ae75b42139c5336e28293" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->

--- a/hikey.xml
+++ b/hikey.xml
@@ -14,7 +14,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="75065d7a22b08115477ae75b42139c5336e28293" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="patches_hikey"        name="linaro-swg/patches_hikey.git"          revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -21,7 +21,7 @@
         <project path="arm-trusted-firmware"  name="ARM-software/arm-trusted-firmware.git"    revision="refs/tags/v1.5-rc2" clone-depth="1" />
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="linux"                 name="96boards-hikey/linux.git"                 revision="3ad676355df5813eed03c10d9b259fe06227f41e" />
+        <project path="linux"                 name="linaro-swg/linux.git"                     revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="91eb48cee84cf3f74ea4753309500ea428ebdfff" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />

--- a/juno.xml
+++ b/juno.xml
@@ -14,7 +14,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="75065d7a22b08115477ae75b42139c5336e28293"/>
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -14,7 +14,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="75065d7a22b08115477ae75b42139c5336e28293" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />


### PR DESCRIPTION
HiKey960 is now properly supported by upstream kernel v4.19, so drop the
platform-specific fork and use the new tip of our multi-platform
linaro-swg/linux/optee branch (which was recently rebased onto v4.19).
While we're at it, also upgrade other platforms.

Change-Id: I77d03d71350808561dfff0c90a4a8307ce274d9a
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>