### PR TITLE
Add manifests to point to ms-iot forks

### DIFF
--- a/oe_default.xml
+++ b/oe_default.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+        <remote name="github" fetch="https://github.com" />
+
+        <default remote="github" revision="master" />
+
+        <!-- ms-iot gits -->
+        <project path="optee_client"        name="ms-iot/optee_client.git"                revision="ms-optee-ocalls"/>
+        <project path="optee_os"            name="ms-iot/optee_os.git"                    revision="ms-iot-security"/>
+        <project path="linux"               name="ms-iot/linux.git"                       revision="ms-iot-grapeboard" />
+
+        <!-- OP-TEE gits -->
+        <project path="optee_test"          name="OP-TEE/optee_test.git" />
+        <project path="build"               name="OP-TEE/build.git">
+                <linkfile src="qemu.mk" dest="build/Makefile" />
+        </project>
+
+        <!-- linaro-swg gits -->
+        <project path="u-boot"               name="linaro-swg/u-boot.git"                 revision="optee" />
+        <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
+        <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
+        <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
+
+        <!-- Misc gits -->
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v1.5" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="qemu/dtc"             name="qemu/dtc.git"                          revision="refs/tags/v1.4.6" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v2.12.0" clone-depth="1" />
+</manifest>

--- a/oe_qemu_v8.xml
+++ b/oe_qemu_v8.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+        <remote name="github"   fetch="https://github.com" />
+
+        <default remote="github" revision="master" />
+
+        <!-- ms-iot gits -->
+        <project path="optee_client"        name="ms-iot/optee_client.git"                revision="ms-optee-ocalls"/>
+        <project path="optee_os"            name="ms-iot/optee_os.git"                    revision="ms-iot-security"/>
+        <project path="linux"               name="ms-iot/linux.git"                       revision="ms-iot-grapeboard" />
+
+        <!-- OP-TEE gits -->
+        <project path="optee_test"           name="OP-TEE/optee_test.git" />
+        <project path="build"                name="OP-TEE/build.git">
+                <linkfile src="qemu_v8.mk" dest="build/Makefile" />
+                <linkfile src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb" dest="build/gdb" />
+        </project>
+
+        <!-- linaro-swg gits -->
+        <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
+        <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
+        <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
+
+        <!-- Misc gits -->
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v1.5-rc2" clone-depth="1" />
+        <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v2.12.0" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+</manifest>


### PR DESCRIPTION
Create two new manifests for QEMU based of the ones for ARMv7 and ARMv8, respectively. These have the Linux, OP-TEE OS and OP-TEE Client repositories pointing to the corresponding forks under ms-iot. The rationale is that these forks have OCALL support, so that if developers want to test their OE enclaves under QEMU, they need build our forks instead of the upstream versions.