### PR TITLE
QEMU, QEMUv8: update QEMU to v3.1.0-rc3 and TF-A to commit on master …

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -20,8 +20,8 @@
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="bde0f3279dc9368b013dbe45f123648580d991ff" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
         <project path="qemu/dtc"             name="qemu/dtc.git"                          revision="refs/tags/v1.4.6" clone-depth="1" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v2.12.0" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -20,8 +20,8 @@
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="bde0f3279dc9368b013dbe45f123648580d991ff" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v2.12.0" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
…branch

This patch upgrades to QEMU v3.1.0-rc3 (the latest at this time) so that
optee_os pull request 2673 [1] may be marged safely.

PR 2673 introduces a patch ("core: console: secure/non secure chosen
console") that causes OP-TEE to fallback to using the console specified in
the Device Tree property /chosen/stdout-path if /secure-chosen does not
exist. This complies with the DT binding [2], but would cause a regression
on QEMU because the version we are using currently does not export
/secure-chosen/stdout-path in the DT it generates. Therefore the console
output from secure world would stop going to the "early console"
hard-coded in OP-TEE and would be switched to the same UART used by the
normal world. QEMU v3.1.0-rc0 or later have a patch ("hw/arm/virt: add DT
property /secure-chosen/stdout-path indicating secure UART") [3] that
avoids this issue.

Arm TF-A is also upgraded to a more recent version than v2.0, namely
commit bde0f3279dc9 ("qemu: increase PLAT_QEMU_DT_MAX_SIZE to 1 MiB")
[4] which is a prerequisite for using QEMU >= v2.12.1.

Change-Id: If057f336cd570bc0624e336ab0c920a8c223c956
Link: [1] https://github.com/OP-TEE/optee_os/pull/2673
Link: [2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/devicetree/bindings/arm/secure.txt?h=v4.20-rc4
Link: [3] https://github.com/qemu/qemu/commit/fb23d693a3
Link: [4] https://github.com/ARM-software/arm-trusted-firmware/commit/bde0f3279dc9
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>