### PR TITLE
default.xml: do not clone DTC

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -22,6 +22,5 @@
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="bde0f3279dc9368b013dbe45f123648580d991ff" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
-        <project path="qemu/dtc"             name="qemu/dtc.git"                          revision="refs/tags/v1.4.6" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
There should be no need to clone qemu/dtc from the manifest file, QEMU
should handle that automatically. In fact I suspect this is the cause of
the following build error in Travis:

 Cloning into '/home/travis/optee_repo/qemu/tests/fp/berkeley-softfloat-3'...
 Cloning into '/home/travis/optee_repo/qemu/tests/fp/berkeley-testfloat-3'...
 Cloning into '/home/travis/optee_repo/qemu/ui/keycodemapdb'...
 fatal: No remote repository specified.  Please, specify either a URL or a
 remote name from which new revisions should be fetched.
 Unable to fetch in submodule path 'dtc'
 ./scripts/git-submodule.sh: failed to update modules

 Unable to automatically checkout GIT submodules ' ui/keycodemapdb tests/fp/berkeley-testfloat-3 tests/fp/berkeley-softfloat-3 dtc capstone'.
 If you require use of an alternative GIT binary (for example to
 enable use of a transparent proxy), then please specify it by
 running configure by with the '--with-git' argument. e.g.

  $ ./configure --with-git='tsocks git'

 Alternatively you may disable automatic GIT submodule checkout
 with:

  $ ./configure --disable-git-update

 and then manually update submodules prior to running make, with:

  $ scripts/git-submodule.sh update  ui/keycodemapdb tests/fp/berkeley-testfloat-3 tests/fp/berkeley-softfloat-3 dtc capstone

 make[1]: *** [git-submodule-update] Error 1
 make: *** [qemu] Error 2
 make: *** Waiting for unfinished jobs....
 The command "(cd ${HOME}/optee_repo/build && $make aarch32 && rm -f ${HOME}/optee_repo/toolchains/gcc-*.tar.xz && $make check BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)" exited with 2.

Change-Id: I8f01241d847e29c7be5b984426934779b2cb23b6
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>