### PR TITLE
Tf a updates emmc fix

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,11 +13,11 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="u-boot"               name="linaro-swg/u-boot.git"                 revision="optee" />
         <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
+        <project path="u-boot"               name="linaro-swg/u-boot.git"                 revision="optee" />
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />

--- a/default.xml
+++ b/default.xml
@@ -20,7 +20,7 @@
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="bde0f3279dc9368b013dbe45f123648580d991ff" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
 </manifest>

--- a/dra7xx.xml
+++ b/dra7xx.xml
@@ -10,7 +10,7 @@
         <project path="optee_os"       name="OP-TEE/optee_os.git" />
         <project path="optee_test"     name="OP-TEE/optee_test.git" />
         <project path="build"          name="OP-TEE/build.git">
-		<linkfile src="dra7xx.mk" dest="build/Makefile" />
+                <linkfile src="dra7xx.mk" dest="build/Makefile" />
         </project>
 
         <!-- linaro-swg gits -->

--- a/fvp.xml
+++ b/fvp.xml
@@ -18,7 +18,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />

--- a/fvp.xml
+++ b/fvp.xml
@@ -19,8 +19,8 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
 </manifest>

--- a/hikey.xml
+++ b/hikey.xml
@@ -19,7 +19,7 @@
         <project path="patches_hikey"        name="linaro-swg/patches_hikey.git"          revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="d75cfac3877be68bb5e36be3fc57ba597a2d3710" />
         <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="bee2ea1660f3a03df8d391fb75aa08dbc3441856" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />

--- a/hikey.xml
+++ b/hikey.xml
@@ -21,11 +21,11 @@
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="d75cfac3877be68bb5e36be3fc57ba597a2d3710" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
         <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="bee2ea1660f3a03df8d391fb75aa08dbc3441856" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="l-loader"             name="96boards-hikey/l-loader.git"           revision="49db0a01f8cc4f2a7e0dea01d843d72092635870" />
         <project path="OpenPlatformPkg"      name="96boards-hikey/OpenPlatformPkg.git"    revision="fbdd4aeee4d8de04d1c332379b20efb7a59a9502" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
 </manifest>

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -18,7 +18,7 @@
         <project path="patches_hikey"         name="linaro-swg/patches_hikey.git"             revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware"  name="ARM-software/arm-trusted-firmware.git"    revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware"  name="ARM-software/arm-trusted-firmware.git"    revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="linux"                 name="linaro-swg/linux.git"                     revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -19,11 +19,11 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware"  name="ARM-software/arm-trusted-firmware.git"    revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
+        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2018.08" clone-depth="1" />
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="linux"                 name="linaro-swg/linux.git"                     revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="91eb48cee84cf3f74ea4753309500ea428ebdfff" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />
-        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2018.08" clone-depth="1" />
 </manifest>

--- a/juno.xml
+++ b/juno.xml
@@ -18,7 +18,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2018.03" clone-depth="1" />
         <project path="vexpress-firmware"    name="arm/vexpress-firmware.git"             revision="670a8336738046ac910f4ed3746edc1b4ecf086c" remote="linaro"/>

--- a/poplar.xml
+++ b/poplar.xml
@@ -22,6 +22,6 @@
         <project path="u-boot"               name="96boards-poplar/u-boot.git"            revision="latest" clone-depth="1" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -21,7 +21,7 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -20,7 +20,7 @@
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="bde0f3279dc9368b013dbe45f123648580d991ff" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />

--- a/rpi3.xml
+++ b/rpi3.xml
@@ -15,13 +15,12 @@
         </project>
 
         <!-- linaro-swg gits -->
-                 <!-- ARM Trusted Firmware, cannot use refs/tags, since we need current tip and that is not tagged  -->
         <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-4.14" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.0" clone-depth="1" />
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
         <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20170215" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="a032e0a6aed208977f48e78d2cc497b91543beaf" />


### PR DESCRIPTION
This updates TF-A to include the patch the fixes the boot regression on the old HiKey. Unfortunately there is not tag to use, so I've change all xml-files to use a defined commit now.

I've tested this on HiKey
```bash
repo init -u https://github.com/jbech-linaro/manifest.git -b tf-a-updates-emmc-fix -m hikey.xml --reference ~/devel/reference
```

and QEMU-v8
```bash
repo init -u https://github.com/jbech-linaro/manifest.git -b tf-a-updates-emmc-fix -m qemu_v8.xml --reference ~/devel/optee_projects/reference
```

The same repo commands can be used if you want to give it a try on another platform who are using TF-A.

Both boot up as expected and xtest passes.

```bash
# Hikey
23665 subtests of which 0 failed
90 test cases of which 0 failed
0 test case was skipped
TEE test application done!
```

```bash
# QEMU v8
23299 subtests of which 0 failed
89 test cases of which 0 failed
0 test case was skipped
TEE test application done!
```

The second patch just sorts things alphabetically in accordance with the instructions in the README.md file.