### PR TITLE
Add support for Raspberry Pi 3 B plus

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -22,6 +22,6 @@
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="023bc019e95ca98687f015074c938941a0546eb7" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
-        <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20170215" clone-depth="1" />
+        <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20190401" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="aac0c29d4b8418c5c78b552070ffeda022b16949" />
 </manifest>


### PR DESCRIPTION
Add a new manifest for Raspberry Pi 3 B+ that pulls in
the start* firmware binaries needed to boot it up.

Signed-off-by: Philby John <philby.j@hcl.com>
Signed-off-by: Vv Ramya <ramyavv@hcl.com>