### PR TITLE
Qemu v7/v8: Stepping up Linux kernel and Buildroot

### DIFF
--- a/am43xx.xml
+++ b/am43xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git"       revision="master" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/am57xx.xml
+++ b/am57xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git"       revision="master" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
@@ -21,6 +21,6 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
 </manifest>

--- a/dra7xx.xml
+++ b/dra7xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git"       revision="master" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/fvp.xml
+++ b/fvp.xml
@@ -14,12 +14,12 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />

--- a/hikey.xml
+++ b/hikey.xml
@@ -14,14 +14,14 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="patches_hikey"        name="linaro-swg/patches_hikey.git"          revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
         <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="d75cfac3877be68bb5e36be3fc57ba597a2d3710" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="bee2ea1660f3a03df8d391fb75aa08dbc3441856" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="77326b5a153513c826d5a50363eace6ef6b59413" />

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -19,10 +19,10 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware"  name="ARM-software/arm-trusted-firmware.git"    revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
-        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="linux"                 name="linaro-swg/linux.git"                     revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
+        <project path="linux"                 name="linaro-swg/linux.git"                     revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="91eb48cee84cf3f74ea4753309500ea428ebdfff" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />

--- a/juno.xml
+++ b/juno.xml
@@ -14,12 +14,12 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d"/>
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2018.03" clone-depth="1" />
         <project path="vexpress-firmware"    name="arm/vexpress-firmware.git"             revision="670a8336738046ac910f4ed3746edc1b4ecf086c" remote="linaro"/>
 </manifest>

--- a/poplar.xml
+++ b/poplar.xml
@@ -23,5 +23,5 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -14,14 +14,14 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="221a1acee8047ae65c2d5980e3a7c5f73362c59d" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
 </manifest>

--- a/rpi3.xml
+++ b/rpi3.xml
@@ -21,7 +21,7 @@
 
         <!-- Misc gits -->
         <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="023bc019e95ca98687f015074c938941a0546eb7" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20170215" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="aac0c29d4b8418c5c78b552070ffeda022b16949" />
 </manifest>


### PR DESCRIPTION
This relates to the changes in https://github.com/OP-TEE/build/pull/340. Here I've stepped up Linux kernel to the commit that we merged last week (5.1 based). I've also stepped up Buildroot to the commit just before optee_client was officially introduced in Buildroot. The reason for not using any later commit is because I saw some build regression with optee_client, when using build.git + more recent Buildroot. This means that if we want to step up Buildroot even more, then we must fix that issue.

When https://github.com/OP-TEE/build/pull/340 has been merged, I'll probably continue updating a few more builds (fvp, hikey and Rpi3), so they also track more or less the same commits as QEMU v7/v8.