### PR TITLE
qemu-v7: Link to the gdb binary on repo sync

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,6 +10,7 @@
         <project path="optee_test"          name="OP-TEE/optee_test.git" />
         <project path="build"               name="OP-TEE/build.git">
                 <linkfile src="qemu.mk" dest="build/Makefile" />
+                <linkfile src="../toolchains/aarch32/bin/arm-linux-gnueabihf-gdb" dest="build/gdb" />
         </project>
 
         <!-- linaro-swg gits -->


### PR DESCRIPTION
Add a link to GDB in build.git to make it easy and convenient to run gdb
from the same folder as used when compiling and running the full OP-TEE
developer setup.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>