### PR TITLE
hikey960: update l-loader

### DIFF
--- a/hikey960.xml
+++ b/hikey960.xml
@@ -23,7 +23,7 @@
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="linux"                 name="linaro-swg/linux.git"                     revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
-        <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc" />
+        <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="a0c5d726cd2a9984f1cb98f0123969cfccce990d" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="91eb48cee84cf3f74ea4753309500ea428ebdfff" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />
 </manifest>


### PR DESCRIPTION
Updates l-loader to the tip of branch testing/hikey960_v1.2. Fixes an
issue with "make recovery" remaining stuck at:

 NOTICE:  BL1-FWU: *******FWU Process Started*******

"git bisect" reports that the fix is commit 461b27f4900b ("hikey960:
add Trusted Board Boot feature"). This commit allows for a bigger size
for TF-A BL1. The problem was introduced when we upgraded TF-A from
v1.5-rc2 to v2.0 [1] but was unnoticed at the time.

Fixes: [1] 5af25841ef84 ("Update Arm TF-A to v2.0")
Change-Id: I3ec8d782c1e12e4f9b03fbf6b03c41f3729ccb9d
Signed-off-by: Jerome Forissier <jerome@forissier.org>