### PR TITLE
TI: remove 'master' from revision in optee_examples

### DIFF
--- a/am43xx.xml
+++ b/am43xx.xml
@@ -14,7 +14,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="optee_examples" name="linaro-swg/optee_examples.git"       revision="master" />
+        <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
         <project path="buildroot"      name="buildroot/buildroot.git"             revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />

--- a/am57xx.xml
+++ b/am57xx.xml
@@ -14,7 +14,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="optee_examples" name="linaro-swg/optee_examples.git"       revision="master" />
+        <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
         <project path="buildroot"      name="buildroot/buildroot.git"             revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />

--- a/dra7xx.xml
+++ b/dra7xx.xml
@@ -14,7 +14,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="optee_examples" name="linaro-swg/optee_examples.git"       revision="master" />
+        <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
         <project path="buildroot"      name="buildroot/buildroot.git"             revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />


### PR DESCRIPTION
All OP-TEE related gits at GitHub will by default track the master
branch in the upstream gits, that is true also for optee_examples,
therefore let's remove the 'revision' from the optee_examples line in
the manifest files for TI devices.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>