### PR TITLE
Restore broken (empty) juno.xml

### DIFF
--- a/juno.xml
+++ b/juno.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+        <remote name="github" fetch="https://github.com" />
+        <remote name="linaro" fetch="https://git.linaro.org" />
+
+        <default remote="github" revision="master" />
+
+        <!-- OP-TEE gits -->
+        <project path="optee_client"         name="OP-TEE/optee_client.git" revision="refs/tags/3.6.0" clone-depth="1" />
+        <project path="optee_os"             name="OP-TEE/optee_os.git" revision="refs/tags/3.6.0" clone-depth="1" />
+        <project path="optee_test"           name="OP-TEE/optee_test.git" revision="refs/tags/3.6.0" clone-depth="1" />
+        <project path="build"                name="OP-TEE/build.git" revision="refs/tags/3.6.0" clone-depth="1">
+                <linkfile src="juno.mk" dest="build/Makefile" />
+        </project>
+
+        <!-- linaro-swg gits -->
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c"/>
+        <project path="optee_examples"       name="linaro-swg/optee_examples.git" revision="refs/tags/3.6.0" clone-depth="1" />
+
+        <!-- Misc gits -->
+        <project path="arm-trusted-firmware" name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2018.08" clone-depth="1" />
+        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2018.03" clone-depth="1" />
+        <project path="vexpress-firmware"    name="arm/vexpress-firmware.git"             revision="670a8336738046ac910f4ed3746edc1b4ecf086c" remote="linaro"/>
+</manifest>


### PR DESCRIPTION
For some reason the juno.xml file was deleted in branch and tag 3.6.0.
Restore it.

Change-Id: I54f1e7134501ca9246236d069baa6ba8d21f79d3
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>