### PR TITLE
fix ARM trusted firmware source repo

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -24,5 +24,5 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
 </manifest>

--- a/fvp.xml
+++ b/fvp.xml
@@ -23,5 +23,5 @@
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
 </manifest>

--- a/hikey.xml
+++ b/hikey.xml
@@ -28,5 +28,5 @@
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="l-loader"             name="96boards-hikey/l-loader.git"           revision="49db0a01f8cc4f2a7e0dea01d843d72092635870" />
         <project path="OpenPlatformPkg"      name="96boards-hikey/OpenPlatformPkg.git"    revision="fbdd4aeee4d8de04d1c332379b20efb7a59a9502" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
 </manifest>

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -26,5 +26,5 @@
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="a0c5d726cd2a9984f1cb98f0123969cfccce990d" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="91eb48cee84cf3f74ea4753309500ea428ebdfff" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />
-        <project path="trusted-firmware-a"    name="TF-A/trusted-firmware-a.git"              revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"    name="ARM-software/arm-trusted-firmware.git"    revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
 </manifest>

--- a/juno.xml
+++ b/juno.xml
@@ -20,7 +20,7 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2018.03" clone-depth="1" />
         <project path="vexpress-firmware"    name="arm/vexpress-firmware.git"             revision="670a8336738046ac910f4ed3746edc1b4ecf086c" remote="linaro"/>
 </manifest>

--- a/poplar.xml
+++ b/poplar.xml
@@ -24,5 +24,5 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -25,5 +25,5 @@
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
 </manifest>

--- a/rpi3.xml
+++ b/rpi3.xml
@@ -23,6 +23,6 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20190401" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="023bc019e95ca98687f015074c938941a0546eb7" remote="tfo"/>
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="023bc019e95ca98687f015074c938941a0546eb7" remote="tfo"/>
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="aac0c29d4b8418c5c78b552070ffeda022b16949" />
 </manifest>

--- a/synquacer.xml
+++ b/synquacer.xml
@@ -17,5 +17,5 @@
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="21d9dc21f81828538af02ca9c2d86a36551b0771" />
         <project path="edk2-non-osi"         name="tianocore/edk2-non-osi.git"            revision="596043ffb61d5f74a9eb334eaa4df683fa975c92" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="22d5f499135a0b43bfb723a983f93c3148d68494" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="49d969bbb3ca7e738bc6ef560e44c0047a9925cc" remote="tfo"/>
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="49d969bbb3ca7e738bc6ef560e44c0047a9925cc" remote="tfo"/>
 </manifest>


### PR DESCRIPTION
The source repository for ARM Trusted Firmware, TF-A/trusted-firmware-a.git, doesn't exist, and has been moved to ARM-software/arm-trusted-firmware.git

Signed-off-by: Spandan Kumar Sahu <spandankumarsahu@gmail.com>