### PR TITLE
Fix link to "Manifests" section on ReadTheDocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Repo manifest for OP-TEE development
-This git containst repo manifests to be able to clone all source code needed to
+This git contains repo manifests to be able to clone all source code needed to
 be able to setup a full OP-TEE developer build.
 
 All official OP-TEE documentation has moved to http://optee.readthedocs.io. The
-information that used to be here in this git can be found under [manifest].
+information that used to be here in this git can be found under [manifests].
 
 // OP-TEE core maintainers
 
-[manifest]: https://optee.readthedocs.io/building/gits/manifest.html
+[manifests]: https://optee.readthedocs.io/en/latest/building/gits/build.html#manifests


### PR DESCRIPTION
The link in README.md was pointing to a non-existent location. It has been fixed to point to the proper section of the documentattion on building OP-TEE.