### PR TITLE
Update QEMU, QEMUv8, HiKey620, HiKey960, Juno and FVP to kernel v5.5

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="1ad01d3482219ee7fcc5a4529f8f06570878bf72" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />

--- a/fvp.xml
+++ b/fvp.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="1ad01d3482219ee7fcc5a4529f8f06570878bf72" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->

--- a/hikey.xml
+++ b/hikey.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="1ad01d3482219ee7fcc5a4529f8f06570878bf72" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="patches_hikey"        name="linaro-swg/patches_hikey.git"          revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -22,7 +22,7 @@
         <project path="buildroot"             name="buildroot/buildroot.git"                  revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="linux"                 name="linaro-swg/linux.git"                     revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
+        <project path="linux"                 name="linaro-swg/linux.git"                     revision="1ad01d3482219ee7fcc5a4529f8f06570878bf72" />
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="a0c5d726cd2a9984f1cb98f0123969cfccce990d" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="91eb48cee84cf3f74ea4753309500ea428ebdfff" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />

--- a/juno.xml
+++ b/juno.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="1ad01d3482219ee7fcc5a4529f8f06570878bf72" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="9823b258b332b4ac98e05fa23448bbc9e937b24c" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="1ad01d3482219ee7fcc5a4529f8f06570878bf72" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />


### PR DESCRIPTION
The optee branch in https://github.com/linaro-swg/linux has been
recently rebased onto Linux v5.5. Record this commit in the manifests.

Change-Id: I36da86d6d5f3d75057cc29b9f35310bd61d7a204
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMU)
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMUv8)
Tested-by: Jerome Forissier <jerome@forissier.org> (HiKey960)