### PR TITLE
repo: remove symlink creation to gdb

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,7 +11,6 @@
         <project path="optee_test"          name="OP-TEE/optee_test.git" />
         <project path="build"               name="OP-TEE/build.git">
                 <linkfile src="qemu.mk" dest="build/Makefile" />
-                <linkfile src="../toolchains/aarch32/bin/arm-linux-gnueabihf-gdb" dest="build/gdb" />
         </project>
 
         <!-- linaro-swg gits -->

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -11,7 +11,6 @@
         <project path="optee_test"           name="OP-TEE/optee_test.git" />
         <project path="build"                name="OP-TEE/build.git">
                 <linkfile src="qemu_v8.mk" dest="build/Makefile" />
-                <linkfile src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb" dest="build/gdb" />
         </project>
 
         <!-- linaro-swg gits -->

--- a/rpi3.xml
+++ b/rpi3.xml
@@ -12,7 +12,6 @@
         <project path="build"                name="OP-TEE/build.git">
                 <linkfile src="rpi3.mk" dest="build/Makefile" />
                 <linkfile src="rpi3/debugger/pi3.cfg" dest="build/pi3.cfg" />
-                <linkfile src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb" dest="build/gdb" />
         </project>
 
         <!-- linaro-swg gits -->


### PR DESCRIPTION
It seems like the newest version of repo (v2.0) no longer allows to
create symlinks to non-existent files. In the past repo has silently
ignored creating the symlink on the first repo sync. However the most
recent version gives an error instead.

Since our setup flow is to create toolchains after checking out the
repo forest, the only viable option we have is to no longer try to
create a symlink. This doesn't really affect anything as such, we just
had it there as a convenience so we could handle builds and debugging
from the same folder on disc.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>