### PR TITLE
qemu: Update TF-A to upstream master (v2.2-615-ge7a540335)

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -23,5 +23,5 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v3.1.0-rc3" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="34efb683e32254b8c325ac3071c5776d243a7b99" remote="tfo" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="e7a5403358bca60a82e6c6d54608f1e2adb83a09" remote="tfo" />
 </manifest>


### PR DESCRIPTION
Commit c91340cdbf11 ("Update TF-A to v2.2 (all platforms but QEMU)")
could not updated default.xml due to a regression upstream. The issue
has now been fixed, so we can reference a commit on the master branch.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMU)
Change-Id: I975c174940256cce830c65fa5be370186bd1a931