### PR TITLE
make_stable: use OP-TEE tag for linaro-swg linux repository

### DIFF
--- a/make_stable.sh
+++ b/make_stable.sh
@@ -53,5 +53,6 @@ do
 		sed "s/\(linaro-swg\/optee_examples.git\"\)/\1 revision=\"refs\/tags\/${VERSION}\" clone-depth=\"1\"/" |
 		sed "s/\(linaro-swg\/optee_benchmark.git\)revision.*/\1\/>/" | # Removes old revision
 		sed "s/\(linaro-swg\/optee_benchmark.git\"\)/\1 revision=\"refs\/tags\/${VERSION}\" clone-depth=\"1\"/" |
+		sed "s/\(linaro-swg\/linux.git\" *\)revision=\"optee\".*/\1revision=\"refs\/tags\/optee-${VERSION}\" clone-depth=\"1\"/" |
 		tee ${FILE} 2>&1 > /dev/null
 done


### PR DESCRIPTION
Change script to use OP-TEE release tag for linaro-swg github Linux
kernel repository when applicable to make sure stable release are
referenced with a immutable reference of the kernel source tree.

This change assumes OP-TEE release tag is also created for that
repository.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>