### PR TITLE
hikey.xml: update burn-boot

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -22,7 +22,7 @@
         <!-- Misc gits -->
         <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="d75cfac3877be68bb5e36be3fc57ba597a2d3710" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
-        <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="bee2ea1660f3a03df8d391fb75aa08dbc3441856" />
+        <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="a55c068f9a0aaf9da440aacdfaf85182e168e36c" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />


### PR DESCRIPTION
Updates burn-boot to the latest version on the master branch, that is
commit a55c068f9a0a ("hisi-idt.py: port to Python 3"). Fixes errors when
flashing a board in recovery mode on a PC running Python 3 by default
(such as Ubuntu 20.04).

Change-Id: Icf7f44889021a223d958b92b730feea7e85dc187
Signed-off-by: Jerome Forissier <jerome@forissier.org>