### PR TITLE
hikey.xml: update burn-boot

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -22,7 +22,7 @@
         <!-- Misc gits -->
         <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="d75cfac3877be68bb5e36be3fc57ba597a2d3710" />
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
-        <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="a55c068f9a0aaf9da440aacdfaf85182e168e36c" />
+        <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="7dcbfb1f1496756294b3068e6e2370a9399dcea2" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />


### PR DESCRIPTION
Some more burn-boot fixes and improvements for HiKey to avoid IBART
erroring out when flashing the board.

Change-Id: I4402338bf92b6f3f5c7caf37db256a850df8c6e8
Link: https://github.com/OP-TEE/optee_os/pull/3959#issuecomment-652511325
Signed-off-by: Jerome Forissier <jerome@forissier.org>