### PR TITLE
qemu: remove deprecated linkfile elements with .. in the path

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,7 +11,6 @@
         <project path="optee_test"          name="OP-TEE/optee_test.git" revision="refs/tags/3.8.0" clone-depth="1" />
         <project path="build"               name="OP-TEE/build.git" revision="refs/tags/3.8.0" clone-depth="1">
                 <linkfile src="qemu.mk" dest="build/Makefile" />
-                <linkfile src="../toolchains/aarch32/bin/arm-linux-gnueabihf-gdb" dest="build/gdb" />
         </project>
 
         <!-- linaro-swg gits -->

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -11,7 +11,6 @@
         <project path="optee_test"           name="OP-TEE/optee_test.git" revision="refs/tags/3.8.0" clone-depth="1" />
         <project path="build"                name="OP-TEE/build.git" revision="refs/tags/3.8.0" clone-depth="1">
                 <linkfile src="qemu_v8.mk" dest="build/Makefile" />
-                <linkfile src="../toolchains/aarch64/bin/aarch64-linux-gnu-gdb" dest="build/gdb" />
         </project>
 
         <!-- linaro-swg gits -->


### PR DESCRIPTION
Newer versions of repo can't build older OP-TEE branches due to the
following error:

 error.ManifestInvalidPathError: <linkfile> invalid "src": ../toolchains/aarch32/bin/arm-linux-gnueabihf-gdb: bad component: ..

This commit removes the problematic elements in the QEMU manifests. They
were just there for convenience.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: If94077ad7c6336e38f0fbcbfe3961037ba6f41b9