### PR TITLE
qemu-v7,v8: step up QEMU version to 5.1.0

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -22,7 +22,7 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.0.0" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2020.04" remote="u-boot" clone-depth="1" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -23,6 +23,6 @@
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="95942f5fcd35d783a49adce621ccf33480f1c88c" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.0.0" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />
 </manifest>


### PR DESCRIPTION
Step up the QEMU version used by the OP-TEE builds for QEMU-v7 and -v8
to version 5.1.0. Note that this version generates an internal Device
Tree with a /secure-chosen/kaslr-seed property [1]. Therefore OP-TEE
3.8.0 or later will run with Address Space Layout Randomization enabled
unless CFG_CORE_ASLR=n is set at build time.

Link: [1] https://git.qemu.org/?p=qemu.git;a=commit;h=60592cfed2b685ef114a454d176ef539528cb0cf
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMUv7)
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMUv8)
Change-Id: If69490eaabd6437317111a0d1207c6715fc888ea