### PR TITLE
make_stable.sh: add missing closing tag

### DIFF
--- a/make_stable.sh
+++ b/make_stable.sh
@@ -53,6 +53,6 @@ do
 		sed "s/\(linaro-swg\/optee_examples.git\"\)/\1 revision=\"refs\/tags\/${VERSION}\" clone-depth=\"1\"/" |
 		sed "s/\(linaro-swg\/optee_benchmark.git\)revision.*/\1\/>/" | # Removes old revision
 		sed "s/\(linaro-swg\/optee_benchmark.git\"\)/\1 revision=\"refs\/tags\/${VERSION}\" clone-depth=\"1\"/" |
-		sed "s/\(linaro-swg\/linux.git\" *\)revision=\"optee\".*/\1revision=\"refs\/tags\/optee-${VERSION}\" clone-depth=\"1\"/" |
+		sed "s/\(linaro-swg\/linux.git\" *\)revision=\"optee\".*/\1revision=\"refs\/tags\/optee-${VERSION}\" clone-depth=\"1\" \/>/" |
 		tee ${FILE} 2>&1 > /dev/null
 done


### PR DESCRIPTION
When make_stable.sh replaces the linux project entry with a new one
pointing to a release tag, it lacks an XML closing tag '/>' which
causes an error with 'repo sync':

 $ repo sync optee*
 fatal: error parsing manifest /home/jerome/work/optee_repo_qemu/.repo/manifest.xml: not well-formed (invalid token): line 19, column 8

Add the missing bit.

Fixes: f7824ba5119e ("make_stable: use OP-TEE tag for linaro-swg linux repository")
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: Icfba9a60624804feadaf457ad9b54383f33f9aee