### PR TITLE
qemu, qemuv8: use master branch for soc_term

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -18,7 +18,7 @@
         <project path="linux"                name="linaro-swg/linux.git"                  revision="optee" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
-        <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
+        <project path="soc_term"             name="linaro-swg/soc_term.git" />
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -17,7 +17,7 @@
         <project path="linux"                name="linaro-swg/linux.git"                  revision="optee" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
-        <project path="soc_term"             name="linaro-swg/soc_term.git"               revision="5493a6e7c264536f5ca63fe7511e5eed991e4f20" />
+        <project path="soc_term"             name="linaro-swg/soc_term.git" />
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />


### PR DESCRIPTION
Consistent with the other OP-TEE/ and linaro-swg/ projects, use the
latest version of soc_term (the master branch) to avoid the need for a
manifest update when a bug is fixed in soc_term.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: Iada78f11d7ce11afe5d3d9cf0a7916e0f2bfb299