### PR TITLE
hikey: add benchmark to the manifest

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -16,6 +16,7 @@
 
         <!-- linaro-swg gits -->
         <project path="linux"                name="linaro-swg/linux.git"                  revision="optee" clone-depth="1" />
+        <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
         <project path="patches_hikey"        name="linaro-swg/patches_hikey.git"          revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 


### PR DESCRIPTION
Having optee_benchmark available after repo init / repo sync is useful
from developer point of view as well from a testing point of view,
therefore add optee_benchmark to the hikey.xml manifest file.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>