### PR TITLE
hikey, hikey960: use https: instead of git: to clone Grub

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
         <remote name="github"   fetch="https://github.com" />
-        <remote name="savannah" fetch="git://git.savannah.gnu.org" />
+        <remote name="savannah" fetch="https://git.savannah.gnu.org" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
 
         <default remote="github" revision="master" />

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
         <remote name="github"   fetch="https://github.com" />
-        <remote name="savannah" fetch="git://git.savannah.gnu.org" />
+        <remote name="savannah" fetch="https://git.savannah.gnu.org" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
 
         <default remote="github" revision="master" />


### PR DESCRIPTION
Change the protocol used to clone Grub from Git to HTTPS. The latter is
more widely used and less likely to be unavailable or cause network
issues due to firewalls, etc. Today for instance the repository is
available over HTTPS but not over Git [1]:

 fatal: read error: Connection reset by peer
 error: Cannot fetch grub.git from git://git.savannah.gnu.org/grub.git

Link: [1] https://optee.mooo.com:5000/logs/OP-TEE/optee_test/469/529502990/fffbe60112bd663ce04c36016fc9cb516feb3d3c
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: I41de91edc455d3009baf683f9b4b24de1b5309c4