### PR TITLE
hikey, hikey960: fix Grub URL

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
         <remote name="github"   fetch="https://github.com" />
-        <remote name="savannah" fetch="https://git.savannah.gnu.org" />
+        <remote name="savannah" fetch="https://git.savannah.gnu.org/git" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
 
         <default remote="github" revision="master" />

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
         <remote name="github"   fetch="https://github.com" />
-        <remote name="savannah" fetch="https://git.savannah.gnu.org" />
+        <remote name="savannah" fetch="https://git.savannah.gnu.org/git" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
 
         <default remote="github" revision="master" />


### PR DESCRIPTION
When changing from git: to https:, the project path should have been
adjusted.

Fixes: d91661441a2d ("hikey, hikey960: use https: instead of git: to clone Grub")
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: Ib359bae00d047a2defd17210269a40433bef7011