### PR TITLE
rpi3: update the kernel version for RPi3B to v5.4

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-4.14" clone-depth="1" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-5.4" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 


### PR DESCRIPTION
@jforissier , please wait with merging this until **after** we've released v3.12.0 (i.e., no hurry here). I took the liberty to just push the [rpi3-optee-5.4](https://github.com/linaro-swg/linux/tree/rpi3-optee-5.4) that I created earlier today (and cherry-picked the necessary patches) to our `linaro-swg/linux` tree. I can see that the RPi orgranisation have [more recent versions](https://github.com/raspberrypi/linux/branches). But the v5.4 seems to be what they promote right now, so I thought it's better to stop there first before jumping to v5.11 or something like that.

As an FYI I gave vanilla kernel from upstream a try also with [defconfig](https://github.com/torvalds/linux/blob/master/arch/arm64/configs/defconfig), but that didn't work.