### PR TITLE
qemu_v8: udpate edk2 to tag edk2-stable201905

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -21,7 +21,7 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
-        <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
+        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable201905" sync-s="true" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />


### PR DESCRIPTION
Updates EDK2 to tag edk2-stable201905, which brings Python3 support.
Project attribute sync-s="true" is added because this version of EDK2
has a couple of git submodules.

The most recent tags pull in a lot more code as submodules and that is
not really needed at the moment.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: I96ffbf6736a28482fc1b3dfa8fd3b272ec1f5037