### PR TITLE
Add support for i.MX 8MQuad Evaluation Kit (EVK)

### DIFF
--- a/imx.xml
+++ b/imx.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+        <remote name="github" fetch="https://github.com" />
+        <remote name="linaro" fetch="https://git.linaro.org" />
+        <remote name="tfo"    fetch="https://git.trustedfirmware.org" />
+        <remote name="ca"     fetch="https://source.codeaurora.org/external/imx" />
+
+        <default remote="github" revision="master" />
+
+        <!-- OP-TEE gits -->
+        <project path="optee_client"         name="OP-TEE/optee_client.git" />
+        <project path="optee_os"             name="OP-TEE/optee_os.git" />
+        <project path="optee_test"           name="OP-TEE/optee_test.git" />
+        <project path="build"                name="OP-TEE/build.git">
+                <linkfile src="imx.mk" dest="build/Makefile" />
+        </project>
+
+        <!-- linaro-swg gits -->
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="optee" clone-depth="1" />
+        <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
+
+        <!-- Misc gits -->
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />
+        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2020.10-rc2" clone-depth="1" />
+        <project path="imx-mkimage"          name="imx-mkimage.git"                       revision="refs/tags/rel_imx_5.4.24_2.1.0" clone-depth="1" remote="ca" />
+</manifest>


### PR DESCRIPTION
Adds support for i.MX 8MQuad Evaluation Kit (EVK), also know as
imx8mqevk.

Change-Id: I9eb761d49b0b7ae8701b984f8cb5b5ab54db1b3d
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>