### PR TITLE
Update Buildroot, EDK2 and QEMU

### DIFF
--- a/am43xx.xml
+++ b/am43xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.02" clone-depth="1" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/am57xx.xml
+++ b/am57xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.02" clone-depth="1" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -21,7 +21,7 @@
         <project path="soc_term"             name="linaro-swg/soc_term.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2020.04" remote="u-boot" clone-depth="1" />

--- a/default.xml
+++ b/default.xml
@@ -22,7 +22,7 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="39912c14da07a2dbc73854addcfa0a42596340ac" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2020.04" remote="u-boot" clone-depth="1" />
 </manifest>

--- a/dra7xx.xml
+++ b/dra7xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.02" clone-depth="1" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/fvp.xml
+++ b/fvp.xml
@@ -19,7 +19,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />

--- a/hikey.xml
+++ b/hikey.xml
@@ -22,7 +22,7 @@
 
         <!-- Misc gits -->
         <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="d75cfac3877be68bb5e36be3fc57ba597a2d3710" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="7dcbfb1f1496756294b3068e6e2370a9399dcea2" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="77326b5a153513c826d5a50363eace6ef6b59413" />

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -19,7 +19,7 @@
         <project path="patches_hikey"         name="linaro-swg/patches_hikey.git"             revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 
         <!-- Misc gits -->
-        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2021.02" clone-depth="1" />
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="linux"                 name="linaro-swg/linux.git"                     revision="optee" clone-depth="1" />

--- a/imx.xml
+++ b/imx.xml
@@ -20,7 +20,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2020.10-rc2" clone-depth="1" />
         <project path="imx-mkimage"          name="imx-mkimage.git"                       revision="refs/tags/rel_imx_5.4.24_2.1.0" clone-depth="1" remote="ca" />

--- a/juno.xml
+++ b/juno.xml
@@ -19,7 +19,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.2" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2018.03" clone-depth="1" />
         <project path="vexpress-firmware"    name="arm/vexpress-firmware.git"             revision="670a8336738046ac910f4ed3746edc1b4ecf086c" remote="linaro"/>

--- a/poplar.xml
+++ b/poplar.xml
@@ -24,6 +24,6 @@
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2019.10" clone-depth="1" remote="denx" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.2" clone-depth="1" remote="tfo" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -21,7 +21,7 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
-        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable201905" sync-s="true" />
+        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202102" sync-s="true" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -20,7 +20,7 @@
         <project path="soc_term"             name="linaro-swg/soc_term.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable201905" sync-s="true" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -23,6 +23,6 @@
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202102" sync-s="true" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v5.1.0" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="39912c14da07a2dbc73854addcfa0a42596340ac" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />
 </manifest>

--- a/rpi3.xml
+++ b/rpi3.xml
@@ -20,7 +20,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20190401" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.2" clone-depth="1" remote="tfo"/>
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="aac0c29d4b8418c5c78b552070ffeda022b16949" />

--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -21,7 +21,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.02" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.3" remote="tfo" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git" revision="refs/tags/v2020.04" remote="u-boot" clone-depth="1" />
 </manifest>

--- a/verdin.xml
+++ b/verdin.xml
@@ -21,5 +21,5 @@
         <project path="trusted-firmware-a"   name="igoropaniuk/trusted-firmware-a"  revision="verdin_latest" clone-depth="1" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"         revision="refs/tags/2020.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"         revision="refs/tags/2021.02" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
As disscussed in https://github.com/OP-TEE/manifest/issues/179
+ Buildroot fixed the glibc 2.33 compatibility [issue](https://git.busybox.net/buildroot/commit/?id=f45925a951318e9e53bead80b363e004301adc6f) (`_STAT_VER` was removed in glibc 2.33), we should upgrade the Buildroot to reflect that change.
+ EDK2 fixed its incompatibility with python 3.9, so we should update it to edk2-stable202102
+ QEMU fails to build with binutils 2.35 (https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/1907789), hence, we need to update it to the latest version.
