### PR TITLE
stm32mp1: bump u-boot to v2021.04 and tf-a to v2.4

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -22,6 +22,6 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.02" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.3" remote="tfo" clone-depth="1" />
-        <project path="u-boot"               name="u-boot.git" revision="refs/tags/v2020.04" remote="u-boot" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.4" remote="tfo" clone-depth="1" />
+        <project path="u-boot"               name="u-boot.git" revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Bump u-boot to version v2021.04 and TF-A to version v2.4 in stm32mp1 platform manifest.