### PR TITLE
fvp: update TF-A to v2.5

### DIFF
--- a/fvp.xml
+++ b/fvp.xml
@@ -23,5 +23,5 @@
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.2" clone-depth="1" remote="tfo" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo" />
 </manifest>


### PR DESCRIPTION
Tested with Foundation Platform FVP v11.14.34.

xtest results:
25873 subtests of which 0 failed                                                                                                   
92 test cases of which 0 failed                                                                                                    
0 test cases were skipped                                                                                                          
TEE test application done! 