### PR TITLE
qemu_v8: add uboot repo

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -2,7 +2,7 @@
 <manifest>
         <remote name="github"   fetch="https://github.com" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
-
+        <remote name="u-boot" fetch="https://gitlab.denx.de/u-boot" />
         <default remote="github" revision="master" />
 
         <!-- OP-TEE gits -->
@@ -25,4 +25,5 @@
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v6.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />
+        <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
This repo is required to demo bootflows with uboot as BL33.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>