### PR TITLE
qemu_v8: use https:// instead of git:// for Xen repo

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -3,7 +3,7 @@
         <remote name="github"   fetch="https://github.com" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
         <remote name="u-boot"   fetch="https://source.denx.de/u-boot" />
-        <remote name="xen-git"  fetch="git://xenbits.xen.org" />
+        <remote name="xen-git"  fetch="https://xenbits.xen.org/git-http" />
         <default remote="github" revision="master" />
 
         <!-- OP-TEE gits -->


### PR DESCRIPTION
For the unlucky people working behind a corporate proxy, it may be
difficult to access repositories using the git:// protocol. Use
https:// instead.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: I80e53a03b86068d7cb2688d17c7ea6be59cab553