### PR TITLE
hikey960: upgrade trusted-firmware-a to v2.5

### DIFF
--- a/hikey960.xml
+++ b/hikey960.xml
@@ -26,5 +26,5 @@
         <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="a0c5d726cd2a9984f1cb98f0123969cfccce990d" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="245344ea5421ba126e1eb76484d00b590a4a78f7" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />
-        <project path="trusted-firmware-a"    name="TF-A/trusted-firmware-a.git"              revision="refs/tags/v2.2" clone-depth="1" remote="tfo" />
+        <project path="trusted-firmware-a"    name="TF-A/trusted-firmware-a.git"              revision="refs/tags/v2.5" clone-depth="1" remote="tfo" />
 </manifest>


### PR DESCRIPTION
Updagrade Trusted Firmware-A to version v2.5.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: I211b78c5742facdecef1c5db8144cd2c8b2484cf