### PR TITLE
qemu_v8: update Xen to 4.15.0

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -27,5 +27,5 @@
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v6.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />
-        <project path="xen"                  name="xen.git"                               revision="refs/tags/RELEASE-4.14.1" remote="xen-git" clone-depth="1" />
+        <project path="xen"                  name="xen.git"                               revision="refs/tags/RELEASE-4.15.0" remote="xen-git" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Xen 4.15.0 fixes a harmless but ugly warning:

 $ make XEN_BOOT=y run
 [...]
 $ xtest 1013
 [...]
 o regression_1013.1.4 SHA-256 loop repeat 1000
 (XEN) d0v0 Saved RPC cookie does not corresponds to OP-TEE's (ffff6439e9e00e00 != ffff6439e9e00a80)
 (XEN) Xen WARN at optee.c:1147
 (XEN) ----[ Xen-4.14.1  arm64  debug=n   Not tainted ]----
 (XEN) CPU:    0
 (XEN) PC:     000000000025c5ec optee.c#do_call_with_arg+0x4fc/0x510
 (XEN) LR:     000000000025c5ec
 (XEN) SP:     000080007ffdfd30
 (XEN) CPSR:   80000249 MODE:64-bit EL2h (Hypervisor, handler)
 (XEN)      X0: 00000000002f0028  X1: 0000000000000000  X2: 0000000000000000
 [...]
  regression_1013.1.4 OK

Link: https://github.com/OP-TEE/optee_os/issues/4715
Link: http://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=aace5466996e743a087153ad3f9d8fcf11a76c56
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: Iaf59caee63a43c0a060b7606141d6415ebfa1fe6