### PR TITLE
hikey: upgrade trusted-firmware-a to v2.5

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -29,5 +29,5 @@
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="l-loader"             name="96boards-hikey/l-loader.git"           revision="49db0a01f8cc4f2a7e0dea01d843d72092635870" />
         <project path="OpenPlatformPkg"      name="96boards-hikey/OpenPlatformPkg.git"    revision="245344ea5421ba126e1eb76484d00b590a4a78f7" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.2" clone-depth="1" remote="tfo" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo" />
 </manifest>


### PR DESCRIPTION
Upgrade Trusted Firmware-A to version v2.5.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: I19307a471cb7b6b240235b4de29069dfb382a452