### PR TITLE
stm32mp1: bump to u-boot v2021.07 and tf-a v2.5

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -2,7 +2,7 @@
 <manifest>
         <remote name="github" fetch="https://github.com" />
         <remote name="tfo"    fetch="https://git.trustedfirmware.org" />
-        <remote name="u-boot" fetch="https://gitlab.denx.de/u-boot" />
+        <remote name="u-boot" fetch="https://source.denx.de" />
 
         <default remote="github" revision="master" />
 
@@ -22,6 +22,6 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.02" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.4" remote="tfo" clone-depth="1" />
-        <project path="u-boot"               name="u-boot.git" revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.5" remote="tfo" clone-depth="1" />
+        <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2021.07" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Dump to latest release tags TF-A v2.5 and U-Boot v2021.07.
Update U-Boot repository URL since it changed early 2021.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
Change-Id: Ifb555f9d233a9441db8c3dc644eb6da2faa35949