### PR TITLE
qemu, qemu_v8: remove soc_term

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -18,7 +18,6 @@
         <project path="linux"                name="linaro-swg/linux.git"                  revision="optee" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git" />
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
-        <project path="soc_term"             name="linaro-swg/soc_term.git" />
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -18,7 +18,6 @@
         <project path="linux"                name="linaro-swg/linux.git"                  revision="optee" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
-        <project path="soc_term"             name="linaro-swg/soc_term.git" />
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />


### PR DESCRIPTION
Since build.git commit 1f9ad6d4a5fa ("qemu, qemu_v8: use soc_term.py")
[1], the soc_term project is not used anymore. Remove it from the QEMU
and QEMUv8 manifests.

Link: [1] https://github.com/OP-TEE/build/commit/1f9ad6d4a5fa
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: I1fdf9b369158d796d26107db957fb369b9e1e07d