### PR TITLE
qemu_v8: upgrade EDK2 to edk2-stable202105

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -21,7 +21,7 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
-        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202102" sync-s="true" />
+        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202105" sync-s="true" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v6.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo" />


### PR DESCRIPTION
Update the EDK2 version to edk2-stable202105 which includes the
following commit [1]: "UnitTestFrameworkPkg: Use TianoCore mirror of
cmocka repository". Fixes an issue with the original repository being
occasionally unreachable, which is inconvenient for end users and all
the more so for CI scripts [2].

Link: [1] https://github.com/tianocore/edk2/commit/2ad22420a710dc07e3b644f91a5b55c09c39ecf3
Link: [2] https://dev.azure.com/OPTEE/optee_os/_build/results?buildId=995&view=logs&j=705748f3-7146-5e86-79af-1c0266d20a8c&t=d3458a7d-1a81-5639-8e63-8927d807e53a&l=119
Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: I11640a0ab3345817ba8aea10df31959157f6c3ee