### PR TITLE
qemu_v8: Fix the mbedtls version needed for TF-A v2.5

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -22,7 +22,7 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202105" sync-s="true" />
-        <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.16.0" clone-depth="1" />
+        <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="dfd51b7286407070e40b23defe6cef33f4f120c7" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v6.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo" />


### PR DESCRIPTION
TF-A version v2.5 requires the mbedtls version to be 2.26.0
to support trusted board boot. Older mbedtls version causes
compilation to break with TF_A_TRUSTED_BOARD_BOOT=y.

Fixes: 7b69f4 ("qemu, qemu_v8: use TF-A version v2.5")
Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>