### PR TITLE
poplar: switch to 2021.07 u-boot

### DIFF
--- a/poplar.xml
+++ b/poplar.xml
@@ -21,7 +21,7 @@
         <!-- 96boards-poplar gits -->
         <project path="l-loader"             name="96boards-poplar/l-loader.git"          revision="master" clone-depth="1" />
         <project path="poplar-tools"         name="96boards-poplar/poplar-tools.git"      revision="master" clone-depth="1" />
-        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2019.10" clone-depth="1" remote="denx" />
+        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.07" clone-depth="1" remote="denx" />
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.02" clone-depth="1" />


### PR DESCRIPTION
Switch to 2021.07 U-Boot. Previous used U-Boot version (v2019.10) can
not be build with GCC10 (this is addressed already in commit 018921ee7
("Remove redundant YYLOC global declaration")).

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>