### PR TITLE
rpi3: Update TF-A and U-Boot

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -22,6 +22,6 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
         <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20190401" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.2" clone-depth="1" remote="tfo"/>
-        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="aac0c29d4b8418c5c78b552070ffeda022b16949" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo"/>
+	<project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.10" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Upgrade TF-A to v2.5 and U-Boot to tag v2021.10

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>