### PR TITLE
stm32mp1: bump u-boot to version v2021.10

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -23,5 +23,5 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.08" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.5" remote="tfo" clone-depth="1" />
-        <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2021.07" remote="u-boot" clone-depth="1" />
+        <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2021.10" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Bump U-Boot to version v2021.10 for smt32mp1 platforms.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
Change-Id: I839774994b97f553f5dd1f04b54aaf7805e92486