### PR TITLE
Update buildroot to 2021.11

### DIFF
--- a/am43xx.xml
+++ b/am43xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.11" clone-depth="1" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/am57xx.xml
+++ b/am57xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.11" clone-depth="1" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -20,7 +20,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v6.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2020.04" remote="u-boot" clone-depth="1" />

--- a/dra7xx.xml
+++ b/dra7xx.xml
@@ -17,7 +17,7 @@
         <project path="optee_examples" name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"      name="buildroot/buildroot.git"             revision="refs/tags/2021.11" clone-depth="1" />
         <project path="linux"          name="ti-linux-kernel/ti-linux-kernel.git" revision="00a3beacce33dc14fa301eb5f3fb5a341212e9b4" remote="ti" />
         <project path="u-boot"         name="ti-u-boot/ti-u-boot.git"             revision="c68ed086bd00054e28c46e033385f79104c3f84c" remote="ti" />
 </manifest>

--- a/fvp.xml
+++ b/fvp.xml
@@ -19,7 +19,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />

--- a/hikey.xml
+++ b/hikey.xml
@@ -22,7 +22,7 @@
 
         <!-- Misc gits -->
         <project path="atf-fastboot"         name="96boards-hikey/atf-fastboot.git"       revision="d75cfac3877be68bb5e36be3fc57ba597a2d3710" />
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="burn-boot"            name="96boards-hikey/burn-boot.git"          revision="7dcbfb1f1496756294b3068e6e2370a9399dcea2" />
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="77326b5a153513c826d5a50363eace6ef6b59413" />

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -19,7 +19,7 @@
         <project path="patches_hikey"         name="linaro-swg/patches_hikey.git"             revision="d9c07f0ac0ce5fe57d367be82b8673aae8e81e96" />
 
         <!-- Misc gits -->
-        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"             name="buildroot/buildroot.git"                  revision="refs/tags/2021.11" clone-depth="1" />
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="linux"                 name="linaro-swg/linux.git"                     revision="optee" clone-depth="1" />

--- a/imx.xml
+++ b/imx.xml
@@ -20,7 +20,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.3" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2020.10-rc2" clone-depth="1" />
         <project path="imx-mkimage"          name="imx-mkimage.git"                       revision="refs/tags/rel_imx_5.4.24_2.1.0" clone-depth="1" remote="ca" />

--- a/juno.xml
+++ b/juno.xml
@@ -18,7 +18,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2018.03" clone-depth="1" />
 </manifest>

--- a/poplar.xml
+++ b/poplar.xml
@@ -24,6 +24,6 @@
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.07" clone-depth="1" remote="denx" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.2" clone-depth="1" remote="tfo" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -20,7 +20,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202105" sync-s="true" />
         <project path="mbedtls"              name="ARMmbed/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="8520a2018705edcebfb7e729bd2ced12414fc052" />

--- a/rpi3.xml
+++ b/rpi3.xml
@@ -20,7 +20,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
         <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20190401" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.5" clone-depth="1" remote="tfo"/>
 	<project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.10" clone-depth="1" />

--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -21,7 +21,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.11" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.5" remote="tfo" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2021.10" remote="u-boot" clone-depth="1" />
 </manifest>

--- a/verdin.xml
+++ b/verdin.xml
@@ -21,5 +21,5 @@
         <project path="trusted-firmware-a"   name="igoropaniuk/trusted-firmware-a"  revision="verdin_latest" clone-depth="1" />
 
         <!-- Misc gits -->
-        <project path="buildroot"            name="buildroot/buildroot.git"         revision="refs/tags/2021.08" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"         revision="refs/tags/2021.11" clone-depth="1" />
 </manifest>

--- a/zynqmp.xml
+++ b/zynqmp.xml
@@ -24,5 +24,5 @@
 	<project path="bootgen"			name="Xilinx/bootgen"			revision="refs/tags/xilinx_v2021.1"/>
 
 	<!-- Misc gits -->
-	<project path="buildroot"		name="buildroot/buildroot.git" revision="refs/tags/2021.08" clone-depth="1" />
+	<project path="buildroot"		name="buildroot/buildroot.git" revision="refs/tags/2021.11" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Update buildroot to version 2021.11. Fixes a build error with
qemu_v8.xml and "make XEN_BOOT=y check" (host compiler is
"gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0"):

 ../glib/gspawn.c: In function ‘safe_closefrom’:
 ../glib/gspawn.c:1497:7: error: too few arguments to function ‘close_range’
  1497 |   if (close_range (lowfd, G_MAXUINT) != 0 && errno == ENOSYS)
       |       ^~~~~~~~~~~
 In file included from /usr/include/unistd.h:1204,
                  from /usr/include/x86_64-linux-gnu/bits/sigstksz.h:24,
                  from /usr/include/signal.h:328,
                  from /usr/include/x86_64-linux-gnu/sys/wait.h:36,
                  from ../glib/gspawn.c:25:
 /usr/include/x86_64-linux-gnu/bits/unistd_ext.h:56:12: note: declared here
    56 | extern int close_range (unsigned int __fd, unsigned int __max_fd,
       |            ^~~~~~~~~~~

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Change-Id: Ic07aaa68b14dfcb46799a626edd23b1783c76097