### PR TITLE
qemu_v8: upgrade EDK2 to edk2-stable202202

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -21,7 +21,7 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2021.11" clone-depth="1" />
-        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202105" sync-s="true" />
+        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202202" sync-s="true" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="8520a2018705edcebfb7e729bd2ced12414fc052" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v6.0.0" clone-depth="1" />


### PR DESCRIPTION
With GCC 11.2.0 (default compiler on Ubuntu 22.04), EDK2 fails to build
with the following errors:

 gcc  -c -I ./brotli/c/include -I .. -I ../Include/Common -I ../Include/ -I ../Include/IndustryStandard -I ../Common/ -I .. -I . -I ../Include/X64/ -MD -fshort-wchar -fno-strict-aliasing -fwrapv -fno-delete-null-pointer-checks -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict -Wno-unused-result -nostdlib -g -O2  brotli/c/dec/decode.c -o brotli/c/dec/decode.o
 brotli/c/dec/decode.c:2033:41: error: argument 2 of type ‘const uint8_t *’ {aka ‘const unsigned char *’} declared as a pointer [-Werror=vla-parameter]
  2033 |     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
       |                          ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
 In file included from brotli/c/dec/decode.c:7:
 ./brotli/c/include/brotli/decode.h:204:19: note: previously declared as a variable length array ‘const uint8_t[*decoded_size]’ {aka ‘const unsigned char[*decoded_size]’}
   204 |     const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
       |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 brotli/c/dec/decode.c:2034:14: error: argument 4 of type ‘uint8_t *’ {aka ‘unsigned char *’} declared as a pointer [-Werror=vla-parameter]
  2034 |     uint8_t* decoded_buffer) {
       |     ~~~~~~~~~^~~~~~~~~~~~~~
 In file included from brotli/c/dec/decode.c:7:
 ./brotli/c/include/brotli/decode.h:206:13: note: previously declared as a variable length array ‘uint8_t[encoded_size]’ {aka ‘unsigned char[encoded_size]’}
   206 |     uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
       |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 cc1: all warnings being treated as errors

Upgrading to tag edk2-stable202202 fixes the issue.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Change-Id: I7199366778f45b7b37d4608789de8d5b17fee7e5