### PR TITLE
hikey, hikey960: update l-loader for Python 3

### DIFF
--- a/hikey.xml
+++ b/hikey.xml
@@ -27,7 +27,7 @@
         <project path="busybox"              name="mirror/busybox.git"                    revision="refs/tags/1_24_0" clone-depth="1" />
         <project path="edk2"                 name="96boards-hikey/edk2.git"               revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="l-loader"             name="96boards-hikey/l-loader.git"           revision="49db0a01f8cc4f2a7e0dea01d843d72092635870" />
+        <project path="l-loader"             name="96boards-hikey/l-loader.git"           revision="6560d22743d5ec904ff043d87f7f794336076085" />
         <project path="OpenPlatformPkg"      name="96boards-hikey/OpenPlatformPkg.git"    revision="245344ea5421ba126e1eb76484d00b590a4a78f7" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo" />
 </manifest>

--- a/hikey960.xml
+++ b/hikey960.xml
@@ -23,7 +23,7 @@
         <project path="edk2"                  name="96boards-hikey/edk2.git"                  revision="77326b5a153513c826d5a50363eace6ef6b59413" />
         <project path="grub"                  name="grub.git"                                 revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
         <project path="linux"                 name="linaro-swg/linux.git"                     revision="optee" clone-depth="1" />
-        <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="a0c5d726cd2a9984f1cb98f0123969cfccce990d" />
+        <project path="l-loader"              name="96boards-hikey/l-loader.git"              revision="6560d22743d5ec904ff043d87f7f794336076085" />
         <project path="OpenPlatformPkg"       name="96boards-hikey/OpenPlatformPkg.git"       revision="245344ea5421ba126e1eb76484d00b590a4a78f7" />
         <project path="tools-images-hikey960" name="96boards-hikey/tools-images-hikey960.git" revision="a10d2bf1dca7a1be50fc60e58ed93253c95de076" />
         <project path="trusted-firmware-a"    name="TF-A/trusted-firmware-a.git"              revision="refs/tags/v2.6" clone-depth="1" remote="tfo" />


### PR DESCRIPTION
Updates the l-loader commit to include commit "Convert
gen_loader_hikey.py and gen_loader_hikey960.py to Python 3". As a result
the whole project can be built without Python 2. The python3 command
MUST be available.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Change-Id: I519dd6b129c06eeed81a9af07101e9373515919b