### PR TITLE
qemu_v8: remove Xen repo

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -3,7 +3,6 @@
         <remote name="github"   fetch="https://github.com" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
         <remote name="u-boot"   fetch="https://source.denx.de/u-boot" />
-        <remote name="xen-git"  fetch="https://xenbits.xen.org/git-http" />
         <default remote="github" revision="master" />
 
         <!-- OP-TEE gits -->
@@ -27,5 +26,4 @@
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v6.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />
-        <project path="xen"                  name="xen.git"                               revision="refs/tags/RELEASE-4.14.1" remote="xen-git" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Now that Xen is built from Buildroot, remove the top-level Xen repository.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Change-Id: Ie70e9d01d0b4b70fa58fa2bc002bb8a951f0f0d0