### PR TITLE
fvp: add Trusted Services support

### DIFF
--- a/fvp-ts.xml
+++ b/fvp-ts.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+        <include name="fvp.xml" />
+
+        <remote name="arm-gitlab" fetch="https://git.gitlab.arm.com" />
+
+        <!-- OP-TEE gits -->
+        <!-- Need to remove and re-add to replace Makefile symlink -->
+        <remove-project path="build"                    name="OP-TEE/build.git" />
+        <project        path="build"                    name="OP-TEE/build.git">
+                <linkfile src="fvp-psa-sp.mk" dest="build/Makefile" />
+        </project>
+
+        <!-- linaro-swg gits -->
+        <!-- Replace Linux with mainline version -->
+        <remove-project path="linux"                    name="linaro-swg/linux.git" />
+        <project        path="linux"                    name="torvalds/linux.git"                       revision="refs/tags/v5.16" clone-depth="1" />
+
+        <!-- Misc gits -->
+        <!-- The fTPM is not used in this config -->
+        <remove-project path="ms-tpm-20-ref"            name="microsoft/ms-tpm-20-ref" />
+        <!-- Add Trusted Services Linux drivers -->
+        <project        path="linux-arm-ffa-user"       name="linux-arm/linux-trusted-services.git"     revision="refs/tags/v4.0.0" clone-depth="1" remote="arm-gitlab" />
+        <project        path="linux-arm-ffa-tee"        name="linux-arm/linux-trusted-services.git"     revision="refs/tags/tee-v1" clone-depth="1" remote="arm-gitlab" />
+        <!-- Add Trusted Services project -->
+        <project        path="trusted-services"         name="TS/trusted-services.git"                  revision="integration" remote="tfo" />
+</manifest>


### PR DESCRIPTION
Add new manifest file derived from the existing fvp.xml which includes
the Trusted Services project and its dependencies.

Related PR: https://github.com/OP-TEE/build/pull/571