### PR TITLE
rpi3: Update Linux to v5.17

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-5.4" clone-depth="1" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-5.17" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 


### PR DESCRIPTION
The v5.17 branch here is based on the Raspberry Pi organizations 5.17.y
branch (and not from the official Linux kernel upstream tree).

Fixes: https://github.com/linaro-swg/linux/issues/102

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>