### PR TITLE
versal: initial manifest

### DIFF
--- a/versal.xml
+++ b/versal.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<remote name="github"   fetch="https://github.com" />
+	<default remote="github" revision="master" />
+
+	<!-- OP-TEE gits -->
+	<project path="optee_client"		name="OP-TEE/optee_client.git" />
+	<project path="optee_docs"		name="OP-TEE/optee_docs.git" />
+	<project path="optee_test"		name="OP-TEE/optee_test.git" />
+	<project path="build"			name="OP-TEE/build.git" >
+		<linkfile src="versal.mk" dest="build/Makefile" />
+	</project>
+
+	<!-- linaro-swg gits -->
+	<project path="optee_benchmark"		name="linaro-swg/optee_benchmark.git" />
+	<project path="optee_examples"		name="linaro-swg/optee_examples.git" />
+
+	<!-- Foundries.io gits - upstream work in progress -->
+	<project path="arm-trusted-firmware"	name="foundriesio/arm-trusted-firmware.git"  revision="refs/heads/xlnx-v2.7-versal"/>
+	<project path="optee_os"		name="foundriesio/optee_os.git"              revision="refs/tags/mp-88-3.18+fio"/>
+
+	<!-- Xilinx gits -->
+	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"	revision="refs/tags/xilinx-v2022.1"/>
+	<project path="linux"			name="Xilinx/linux-xlnx.git"	revision="refs/tags/xilinx-v2022.1"/>
+	<project path="bootgen"			name="Xilinx/bootgen.git"	revision="refs/tags/xilinx_v2022.1"/>
+
+	<!-- Misc gits -->
+	<project path="buildroot"		name="buildroot/buildroot.git" revision="refs/tags/2021.11" clone-depth="1" />
+</manifest>


### PR DESCRIPTION
Initial manifest to build the Versal ACAP platform.

Tested on the Versal ACAP vck190.

While upstreaming progresses, two of the repositories reference Foundries.io so users can validate all the platform features (eFuse, TRNG, crypto, PUF etc)

It is the expectation that over the coming months - as merges take place - these two repositories will point to the AMD/Xilinx and OP-TEE projects instead.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>