### PR TITLE
stm32mp1: bump U-Boot to 2022.10

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -23,5 +23,5 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.11" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.8" remote="tfo" clone-depth="1" />
-        <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2021.10" remote="u-boot" clone-depth="1" />
+        <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2022.10" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
The recent added board stm32mp157c-dhcom-pdk requires a dts fix [1] to not hang on boot

[1] https://source.denx.de/u-boot/u-boot/-/commit/48d9eaf6826a1816c5f9839a564ea6338da609a7

Signed-off-by: Johann Neuhauser <jneuhauser@dh-electronics.com>

Support of the boards stm32mp157c-dhcom-pdk and stm32mp157a-dhcor-avenger96  for the **OP-TEE developer setup** is completed after merging https://github.com/OP-TEE/manifest/pull/223 and https://github.com/OP-TEE/manifest/pull/219.