### PR TITLE
[RFC] stm32mp1: add scp-firmware repository

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -24,4 +24,5 @@
         <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.11" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.8" remote="tfo" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2022.10" remote="u-boot" clone-depth="1" />
+        <project path="scp-firmware"         name="ARM-software/SCP-firmware.git" />
 </manifest>


### PR DESCRIPTION
Clone scp-firmware repository for integration of SCMI server reference implementation in OP-TEE when CFG_SCMI_SERVER=y.

The current scp-firmware mainline repository URL is [1] and is on process to move to [2]. However, implementation of OP-TEE environment support is scp-firmware is still under review in [3] hence here synchronize on Vincent's development branch until SCP-firmware officially support OP-TEE execution environment.

Change-Id: I7f86861cae4d017dc64b83a74fc243cde3ab2c0a
Link: [1] https://github.com/ARM-software/SCP-firmware.git
Link: [2] https://git.gitlab.arm.com/arm-reference-solutions/scp-firmware.git
Link: [3] https://github.com/vingu-linaro/SCP-firmware.git
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>