### PR TITLE
stm32mp1: bump TF-A to v2.8 to support new boards

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -22,6 +22,6 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git" revision="refs/tags/2021.11" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.6" remote="tfo" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.8" remote="tfo" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2021.10" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
The boards stm32mp157c-dhcom-pdk [1] and stm32mp157a-dhcor-avenger96 [2] are supported since TF-A release v2.8.

[1] https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/commit/?id=eef485abb13b6df9a94137edd82904aab0ecf02d
[2] https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/commit/?id=51e223058fe70b311542178f1865514745fa7874

Signed-off-by: Johann Neuhauser <jneuhauser@dh-electronics.com>

Support of the boards stm32mp157c-dhcom-pdk and stm32mp157a-dhcor-avenger96  for the **OP-TEE developer setup** is completed after merging https://github.com/OP-TEE/manifest/pull/223 and https://github.com/OP-TEE/manifest/pull/219.