### PR TITLE
Fix syntax error in fvp-ts manifest 3.19.0 release

### DIFF
--- a/fvp-ts.xml
+++ b/fvp-ts.xml
@@ -6,7 +6,7 @@
 
         <!-- OP-TEE gits -->
         <!-- Need to remove and re-add to replace Makefile symlink -->
-        <remove-project path="build"                    name="OP-TEE/build.git" revision="refs/tags/3.19.0" clone-depth="1">
+        <remove-project path="build"                    name="OP-TEE/build.git" />
         <project        path="build"                    name="OP-TEE/build.git" revision="refs/tags/3.19.0" clone-depth="1">
                 <linkfile src="fvp-psa-sp.mk" dest="build/Makefile" />
         </project>


### PR DESCRIPTION
Fixes XML syntax error in `fv-ts.xml`.