### PR TITLE
fvp: Update TF-A version to v2.8 for fvp-ts target

### DIFF
--- a/fvp.xml
+++ b/fvp.xml
@@ -23,8 +23,8 @@
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo" />
-        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.24.0" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.8" clone-depth="1" remote="tfo" />
+        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-2.28.1" />
 
         <!-- fTPM implementation -->
         <project path="ms-tpm-20-ref"        name="microsoft/ms-tpm-20-ref"               revision="98b60a44aba79b15fcce1c0d1e46cf5918400f6a" />


### PR DESCRIPTION
Also update Mbed-TLS to v2.28.1 to satisfy the requirements of the new TF-A version.