### PR TITLE
qemu_v8: Pin optee_rust to the latest version

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -22,7 +22,7 @@
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2022.11.1" clone-depth="1" />
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202202" sync-s="true" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
-        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="0c7d3a6660e156f7618e2b317f8ab18d6d049548" />
+        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="4031e7282a8f398f54faa19acb2b84fab05de877" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v7.2.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />


### PR DESCRIPTION
Pin optee_rust to "Update to GP 1.3.1".

The GP 1.3.1 updates have been tested on the CI of Teaclave TrustZone SDK. I think we can enable the check-rust CI in OP-TEE.

Related link: 
[1] https://github.com/OP-TEE/optee_os/pull/5688
[2] https://github.com/OP-TEE/optee_os/pull/5805