### PR TITLE
imx: use github instead of codeaurora

### DIFF
--- a/imx.xml
+++ b/imx.xml
@@ -3,7 +3,6 @@
         <remote name="github" fetch="https://github.com" />
         <remote name="linaro" fetch="https://git.linaro.org" />
         <remote name="tfo"    fetch="https://git.trustedfirmware.org" />
-        <remote name="ca"     fetch="https://source.codeaurora.org/external/imx" />
 
         <default remote="github" revision="master" />
 
@@ -23,5 +22,5 @@
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2022.11.1" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2020.10-rc2" clone-depth="1" />
-        <project path="imx-mkimage"          name="imx-mkimage.git"                       revision="refs/tags/rel_imx_5.4.24_2.1.0" clone-depth="1" remote="ca" />
+        <project path="imx-mkimage"          name="nxp-imx/imx-mkimage.git"                       revision="refs/tags/rel_imx_5.4.24_2.1.0" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
source.codeaurora.org is closed, use https://github.com/nxp-imx instead.