### PR TITLE
qemu_v8: update U-Boot to v2023.07.02

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -26,5 +26,5 @@
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
         <project path="hafnium"   name="hafnium/hafnium.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
-        <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />
+        <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
QEMUv8 doesn't work anymore with U-Boot (make UBOOT=y run). The boot hangs after a few lines:

 NOTICE:  Booting Trusted Firmware
 NOTICE:  BL1: v2.9(release):v2.9
 NOTICE:  BL1: Built : 11:51:02, Jul 27 2023
 WARNING: Firmware Image Package header check failed.
 NOTICE:  BL1: Booting BL2
 NOTICE:  BL2: v2.9(release):v2.9
 NOTICE:  BL2: Built : 11:51:02, Jul 27 2023
 WARNING: Firmware Image Package header check failed.
 WARNING: Firmware Image Package header check failed.
 WARNING: Firmware Image Package header check failed.
 WARNING: Firmware Image Package header check failed.
 NOTICE:  BL1: Booting BL31
 NOTICE:  BL31: v2.9(release):v2.9
 NOTICE:  BL31: Built : 11:51:02, Jul 27 2023

 U-Boot 2021.04 (Jul 27 2023 - 11:57:09 +0200)

 DRAM:  1 GiB
 [Nothing happens after this point]

Upgrade to the latest version of U-Boot (v2023.07.02) as a first step to fix this. Some additional configuration changes are required and will be submitted to the build repository [1].

Link: https://github.com/OP-TEE/build/
Change-Id: I730ab911e04811514ccaddf5d22523a894cb81da