### PR TITLE
QEMUv8: remove EDK2

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -26,5 +26,5 @@
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.0.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
         <project path="hafnium"   name="hafnium/hafnium.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
-        <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2021.04" remote="u-boot" clone-depth="1" />
+        <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
 </manifest>

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -20,7 +20,6 @@
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2022.11.1" clone-depth="1" />
-        <project path="edk2"                 name="tianocore/edk2.git"                    revision="refs/tags/edk2-stable202202" sync-s="true" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="4031e7282a8f398f54faa19acb2b84fab05de877" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.0.0" clone-depth="1" />


### PR DESCRIPTION
~~Please ignore the first commit ("qemu_v8: update U-Boot to v2023.07.02") which is submitted as https://github.com/OP-TEE/manifest/pull/243.~~ Edit: let's have both commits reviewed here.