### PR TITLE
Add manifest file to support TS on QEMU

### DIFF
--- a/qemu-ts.xml
+++ b/qemu-ts.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+        <include name="qemu_v8.xml" />
+
+        <remote name="arm-gitlab" fetch="https://git.gitlab.arm.com" />
+        <remote name="kernel-org" fetch="https://git.kernel.org" />
+
+        <!-- OP-TEE gits -->
+        <!-- Need to remove and re-add to replace Makefile symlink -->
+        <remove-project path="build"                    name="OP-TEE/build.git" />
+        <project        path="build"                    name="OP-TEE/build.git">
+                <linkfile src="qemu-psa-sp.mk" dest="build/Makefile" />
+        </project>
+
+        <!-- linaro-swg gits -->
+        <!-- Replace Linux with mainline version -->
+        <remove-project path="linux"                    name="linaro-swg/linux.git" />
+        <project        path="linux"                    name="pub/scm/linux/kernel/git/stable/linux.git"        revision="refs/tags/v6.1.34"    clone-depth="1" remote="kernel-org" />
+
+        <!-- Misc gits -->
+        <!-- The fTPM is not used in this config -->
+        <remove-project path="ms-tpm-20-ref"            name="microsoft/ms-tpm-20-ref" />
+        <!-- Add Trusted Services Linux drivers -->
+        <project        path="linux-arm-ffa-user"       name="linux-arm/linux-trusted-services.git"     revision="refs/tags/debugfs-v5.0.1"     clone-depth="1" remote="arm-gitlab" />
+        <project        path="linux-arm-ffa-tee"        name="linux-arm/linux-trusted-services.git"     revision="refs/tags/tee-v1.1.2"         clone-depth="1" remote="arm-gitlab" />
+        <!-- Add Trusted Services project -->
+        <project        path="trusted-services"         name="TS/trusted-services.git"                  revision="e56c7b19eef74afd4f4d8962b1b1ce699f25833d"     remote="tfo" />
+</manifest>


### PR DESCRIPTION
Add required manifest containing all dependencies to deploy trusted-services on QEMU.