### PR TITLE
Update Trusted Services to v1.0.0

### DIFF
--- a/fvp-ts.xml
+++ b/fvp-ts.xml
@@ -22,7 +22,7 @@
         <remove-project path="ms-tpm-20-ref"            name="microsoft/ms-tpm-20-ref" />
         <!-- Add Trusted Services Linux drivers -->
         <project        path="linux-arm-ffa-user"       name="linux-arm/linux-trusted-services.git"     revision="refs/tags/debugfs-v5.0.1"     clone-depth="1" remote="arm-gitlab" />
-        <project        path="linux-arm-ffa-tee"        name="linux-arm/linux-trusted-services.git"     revision="refs/tags/tee-v1.1.2"         clone-depth="1" remote="arm-gitlab" />
+        <project        path="linux-arm-ffa-tee"        name="linux-arm/linux-trusted-services.git"     revision="refs/tags/tee-v2.0.0"         clone-depth="1" remote="arm-gitlab" />
         <!-- Add Trusted Services project -->
-        <project        path="trusted-services"         name="TS/trusted-services.git"                  revision="e56c7b19eef74afd4f4d8962b1b1ce699f25833d"     remote="tfo" />
+        <project        path="trusted-services"         name="TS/trusted-services.git"                  revision="refs/tags/v1.0.0"     remote="tfo" />
 </manifest>

--- a/fvp.xml
+++ b/fvp.xml
@@ -23,8 +23,8 @@
         <project path="edk2"                 name="tianocore/edk2.git"                    revision="dd4cae4d82c7477273f3da455084844db5cca0c0" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git"          revision="02daa58c21f89628b4d8c76f95f3a554289149bc" />
         <project path="grub"                 name="grub.git"                              revision="refs/tags/grub-2.02" clone-depth="1" remote="savannah" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.8" clone-depth="1" remote="tfo" />
-        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-2.28.1" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
+        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.4.0" />
 
         <!-- fTPM implementation -->
         <project path="ms-tpm-20-ref"        name="microsoft/ms-tpm-20-ref"               revision="98b60a44aba79b15fcce1c0d1e46cf5918400f6a" />


### PR DESCRIPTION
- Update the pinned version of TS and the TS TEE drivers. 
  - For TS update change log see https://trusted-services.readthedocs.io/en/v1.0.0/project/change-log.html#version-1-0-0
  - For TEE change log see https://gitlab.arm.com/linux-arm/linux-trusted-services/-/commit/a2d7349a96c3b3afb44bf1555d53f1c46e45a23d
- Update TF-A to v2.9.  This commit depends on https://github.com/OP-TEE/build/pull/693. The FVP will fail to boot without the SPMC manifest update.


