### PR TITLE
qemu_v8: add SCP-firmware repository

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -28,4 +28,5 @@
         <project path="hafnium"   name="hafnium/hafnium.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />
+        <project path="SCP-firmware"         name="ARM-software/SCP-firmware.git"         revision="refs/tags/v2.13.0" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
SCP-firmware can be used to build a SCMI server as a PTA in optee-os. Add it to the manifest for qemu_v8.

