### PR TITLE
stm32mp1: sync with scp-firmware release tag v2.13.0

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -25,7 +25,7 @@
         <project path="edk2"                 name="tianocore/edk2.git" revision="refs/tags/edk2-stable202211" sync-s="true" clone-depth="1" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git" revision="70b67dc9ab89689f26ad5e68a5efeac509a12115" sync-s="true" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git" revision="refs/tags/mbedtls-2.28.1" clone-depth="1" />
-        <project path="scp-firmware"         name="ARM-software/SCP-firmware.git" />
+        <project path="scp-firmware"         name="ARM-software/SCP-firmware.git" revision="refs/tags/v2.13.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.9" remote="tfo" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2024.01-rc1" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Syncs stm32mp1 manifest with SCP-firmware release tag v2.13.0 and sets its Git repository clone depth to a single commit.