### PR TITLE
qemu_v8: add Xen repository using tag RELEASE-4.18.0

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -3,6 +3,7 @@
         <remote name="github"   fetch="https://github.com" />
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
         <remote name="u-boot"   fetch="https://source.denx.de/u-boot" />
+        <remote name="xenbits"  fetch="https://xenbits.xen.org/" />
         <default remote="github" revision="master" />
 
         <!-- OP-TEE gits -->
@@ -26,4 +27,5 @@
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
         <project path="hafnium"   name="hafnium/hafnium.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
+        <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />
 </manifest>


### PR DESCRIPTION
Adds Xen repository to be used when compiling Xen, both the hypervisor itself and the user-space parts built with Buildroot.