### PR TITLE
poplar: switch to latest u-boot master

### DIFF
--- a/poplar.xml
+++ b/poplar.xml
@@ -21,7 +21,7 @@
         <!-- 96boards-poplar gits -->
         <project path="l-loader"             name="96boards-poplar/l-loader.git"          revision="master" clone-depth="1" />
         <project path="poplar-tools"         name="96boards-poplar/poplar-tools.git"      revision="master" clone-depth="1" />
-        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.07" clone-depth="1" remote="denx" />
+        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="697758e7c81131da6db0e3b10515019fe3aca8c9" clone-depth="1" remote="denx" />
 
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2022.11.1" clone-depth="1" />


### PR DESCRIPTION
Switch to the latest U-Boot master which includes these fixes:
- 66a3618b9a poplar: provide more space for kernel image
- 01201dbd3b poplar: use random mac address