### PR TITLE
rpi3: Update Linux to rpi3-optee-6.7

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -15,7 +15,7 @@
         </project>
 
         <!-- linaro-swg gits -->
-        <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-5.17" clone-depth="1" />
+        <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-6.7" clone-depth="1" />
         <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
@@ -23,5 +23,5 @@
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2022.11.1" clone-depth="1" />
         <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20190401" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo"/>
-	<project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.10" clone-depth="1" />
+        <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.10" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Update Linux kernel to v6.7 for the RPi3B build. The branch is based on the forked kernel branch from the Raspberry Pi organization [1]. I've pushed the branch in question to https://github.com/linaro-swg/linux/tree/rpi3-optee-6.7. But for this particular PR, **we should hold of merging it until we've [released 4.1.0](https://github.com/OP-TEE/optee_os/pull/6574)**.

[1] https://github.com/raspberrypi/linux/tree/rpi-6.7.y

