### PR TITLE
qemu_v8: rust: Uprev to no-std branch tip

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -22,7 +22,7 @@
         <!-- Misc gits -->
         <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2022.11.1" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
-        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="3e58869972034b7d4684cf22425b6437107ec23f" />
+        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="bc6ae8911b6ae093e8369a53a42b8c99307f7dc5" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.1.2" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
         <project path="hafnium"   name="hafnium/hafnium.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />


### PR DESCRIPTION
Incorporate a fix for 32-bit Rust TAs runtime abort.