### PR TITLE
common: remove optee_benchmark

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -10,7 +10,6 @@
 
         <!-- linaro-swg gits -->
         <project path="linux"                name="linaro-swg/linux.git"                  revision="optee" clone-depth="1" />
-        <project path="optee_benchmark"      name="linaro-swg/optee_benchmark.git"/>
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- buildroot git -->


### PR DESCRIPTION
Don´t fetch optee_benchmark, as it's not used anymore.