### PR TITLE
Update Buildroot to 2023.11.1

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -13,5 +13,5 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- buildroot git -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2022.11.1" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2023.11.1" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Update Buildroot to the latest released version. One nice side effect is that the source repository for the ncurses package has changed to a more reliable location (I have seen quite a few network timeouts and retries in CI recently, causing a job to exceed 4 hours of build time).