### PR TITLE
versal: tf-a repository relocation

### DIFF
--- a/versal.xml
+++ b/versal.xml
@@ -7,8 +7,8 @@
 
 	<remove-project                         name="linaro-swg/linux.git" />
 
-	<!-- Foundries.io gits - upstream work in progress -->
-	<project path="arm-trusted-firmware"	name="foundriesio/arm-trusted-firmware.git"  revision="refs/heads/xlnx-v2.7-versal"/>
+	<!-- Private maintainer git - Xilinx adoption work is in progress -->
+	<project path="arm-trusted-firmware"	name="ldts/arm-trusted-firmware.git"  revision="refs/heads/xlnx-v2.7-versal"/>
 
 	<!-- Xilinx gits -->
 	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"	revision="refs/tags/xilinx-v2022.1"/>


### PR DESCRIPTION
Due to legal requirements, we were obliged to relocate the TF-A repository from our private GitHub at Foundries.io. While the matter is settled I am redirecting TF-A to my personal repository.