### PR TITLE
qemu_v8: SCP-firmware repository relocation

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -3,6 +3,7 @@
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
         <remote name="u-boot"   fetch="https://source.denx.de/u-boot" />
         <remote name="xenbits"  fetch="https://xenbits.xen.org/" />
+        <remote name="arm-gitlab"       fetch="https://git.gitlab.arm.com/" />
 
         <include name="common.xml" />
         <project path="build"                name="OP-TEE/build.git">
@@ -17,5 +18,5 @@
         <project path="hafnium"   name="hafnium/hafnium.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />
-        <project path="SCP-firmware"         name="ARM-software/SCP-firmware.git"         revision="refs/tags/v2.13.0" clone-depth="1" />
+        <project path="SCP-firmware"         name="firmware/SCP-firmware.git"             revision="refs/tags/v2.13.0" remote="arm-gitlab" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
SCP-firmware has moved from github to Arm gitlab