### PR TITLE
fvp: Add hafnium component to enable running wih SPMC at EL2

### DIFF
--- a/fvp.xml
+++ b/fvp.xml
@@ -8,7 +8,7 @@
                 <linkfile src="fvp.mk" dest="build/Makefile" />
         </project>
 
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.9" clone-depth="1" remote="tfo" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.4.0" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2024.04" remote="u-boot" clone-depth="1" />
 

--- a/fvp.xml
+++ b/fvp.xml
@@ -8,6 +8,7 @@
                 <linkfile src="fvp.mk" dest="build/Makefile" />
         </project>
 
+        <project path="hafnium"              name="hafnium/hafnium.git"                   revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.4.0" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2024.04" remote="u-boot" clone-depth="1" />


### PR DESCRIPTION
Let us add the hafnium component in order to enable building and testing SPMC at EL2. Also update TF-A to match Hafnium version at v2.10