### PR TITLE
Update Buildroot to 2024.02.2

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -13,5 +13,5 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- buildroot git -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2023.11.1" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2024.02.2" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
The current Buildroot version (2023.11.1) causes a build error:

 >>> libzlib 1.3 Downloading
 wget --passive-ftp -nd -t 3 -O '/__w/optee_os/optee/out-br/build/.zlib-1.3.tar.xz.MFXZgl/output' 'https://www.zlib.net/zlib-1.3.tar.xz'
 --2024-05-24 07:33:52--  https://www.zlib.net/zlib-1.3.tar.xz
 Resolving www.zlib.net (www.zlib.net)... 85.187.148.2
 Connecting to www.zlib.net (www.zlib.net)|85.187.148.2|:443... connected.
 HTTP request sent, awaiting response... 404 Not Found

Update to the latest tag to make the error go away (will now get zlib-1.3.1.tar.xz).