### PR TITLE
common: update buildroot to 2024.05

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -13,5 +13,5 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- buildroot git -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2024.02.2" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2024.05" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
With more recent versions of GCC (v14.x), the build fails with implicit declaration of function open_temp_exec_file(...) in libffi. The issue is seen with GCC v14.1.1 and libffi v3.4.4. A fix for this issue was merged in libffi v3.4.6, which is the version we get when updating Buildroot to v2024.05.


Tested-by: Joakim Bech <joakim.bech@linaro.org> (GCC 14.1.1/Fedora 40
           and GCC 11.4.0/Ubuntu 22.04)