### PR TITLE
stm32mp1: update edk2-platform to fix VariableFlashInfoLib build issue

### DIFF
--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -10,7 +10,7 @@
 
         <!-- Misc gits -->
         <project path="edk2"                 name="tianocore/edk2.git" revision="refs/tags/edk2-stable202211" sync-s="true" clone-depth="1" />
-        <project path="edk2-platforms"       name="tianocore/edk2-platforms.git" revision="70b67dc9ab89689f26ad5e68a5efeac509a12115" sync-s="true" clone-depth="1" />
+        <project path="edk2-platforms"       name="tianocore/edk2-platforms.git" revision="5b9002e5f9119a832918c479071d18796349f3f1" sync-s="true" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git" revision="refs/tags/mbedtls-2.28.1" clone-depth="1" />
         <project path="scp-firmware"         name="ARM-software/SCP-firmware.git" revision="refs/tags/v2.13.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.9" remote="tfo" clone-depth="1" />


### PR DESCRIPTION
Sync edk2-platform to fix build issue related to missing VariableFlashInfoLib resource as reported in build error trace message like the below:

edk2-platforms/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc(...): error 4000: Instance of library class [VariableFlashInfoLib] is not found