### PR TITLE
qemu, poplar: get U-Boot from source.denx.de rather than gitlab.denx.de

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
         <remote name="tfo"    fetch="https://git.trustedfirmware.org" />
-        <remote name="u-boot" fetch="https://gitlab.denx.de/u-boot" />
+        <remote name="u-boot" fetch="https://source.denx.de/u-boot" />
 
         <include name="common.xml" />
         <project path="build"               name="OP-TEE/build.git">

--- a/poplar.xml
+++ b/poplar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
         <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
-        <remote name="denx"     fetch="https://gitlab.denx.de" />
+        <remote name="denx"     fetch="https://source.denx.de" />
 
         <include name="common.xml" />
         <project path="build"                name="OP-TEE/build.git" >


### PR DESCRIPTION
THe official domain name for U-Boot source code is source.denx.de not gitlab.denx.de. Update QEMU and Poplar accordingly. Other platforms are already using the correct URL.

Link: https://docs.u-boot.org/en/v2024.04/build/source.html [1]