### PR TITLE
fvp-ts: update to Linux v6.10

### DIFF
--- a/fvp-ts.xml
+++ b/fvp-ts.xml
@@ -15,7 +15,7 @@
         <!-- linaro-swg gits -->
         <!-- Replace Linux with mainline version -->
         <remove-project path="linux"                    name="linaro-swg/linux.git" />
-        <project        path="linux"                    name="pub/scm/linux/kernel/git/stable/linux.git"        revision="refs/tags/v6.1.34"    clone-depth="1" remote="kernel-org" />
+        <project        path="linux"                    name="pub/scm/linux/kernel/git/torvalds/linux.git"      revision="refs/tags/v6.10"      clone-depth="1" remote="kernel-org" />
 
         <!-- Trusted Firmware-A version and its MbedTLS dependency -->
         <extend-project name="TF-A/trusted-firmware-a.git" path="trusted-firmware-a" revision="refs/tags/v2.11" remote="tfo" />
@@ -25,8 +25,7 @@
         <!-- The fTPM is not used in this config -->
         <remove-project path="ms-tpm-20-ref"            name="microsoft/ms-tpm-20-ref" />
         <!-- Add Trusted Services Linux drivers -->
-        <project        path="linux-arm-ffa-user"       name="linux-arm/linux-trusted-services.git"     revision="refs/tags/debugfs-v5.0.1"     clone-depth="1" remote="arm-gitlab" />
-        <project        path="linux-arm-ffa-tee"        name="linux-arm/linux-trusted-services.git"     revision="refs/tags/tee-v2.0.0"         clone-depth="1" remote="arm-gitlab" />
+        <project        path="linux-arm-ffa-user"       name="linux-arm/linux-trusted-services.git"     revision="refs/tags/debugfs-v5.0.2"     clone-depth="1" remote="arm-gitlab" />
         <!-- Add Trusted Services project -->
-        <project        path="trusted-services"         name="TS/trusted-services.git"                  revision="4242972c139b785decc9910ab7e356a63bd72a3b"     remote="tfo" />
+        <project        path="trusted-services"         name="TS/trusted-services.git"                  revision="cc9589c03cb0fcd9c3248b95f05cce1afaa37d0f"     remote="tfo" />
 </manifest>


### PR DESCRIPTION
The TSTEE driver used by Trusted Services has been merged to mainline Linux. Update the kernel version so we can use it and remove the old out-of-tree module. The linux-arm-ffa-user driver also needs to be updated for the new kernel.