### PR TITLE
qemu_v8: replace trustedfirmware.org repositories with their GitHub mirrors

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-        <remote name="tfo"      fetch="https://git.trustedfirmware.org" />
         <remote name="u-boot"   fetch="https://source.denx.de/u-boot" />
         <remote name="xenbits"  fetch="https://xenbits.xen.org/" />
         <remote name="arm-gitlab"       fetch="https://git.gitlab.arm.com/" />
@@ -14,8 +13,8 @@
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="ec3eefd9de68a18d5acee1a151e0d93f6898807f" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.1.2" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
-        <project path="hafnium"   name="hafnium/hafnium.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
+        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.10" clone-depth="1" />
+        <project path="hafnium"              name="TF-Hafnium/hafnium.git"                revision="refs/tags/v2.10" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />
         <project path="SCP-firmware"         name="firmware/SCP-firmware.git"             revision="3d1b98e38686889c5a7b1d91a8c0f22fcfedbbf7" remote="arm-gitlab" clone-depth="1" />


### PR DESCRIPTION
git.trustedfirmware.org has been unreliable and has caused CI errors a couple of times so switch to the GitHub mirrors instead. Another advantage is that GitHub is a bit faster.

Link: https://github.com/OP-TEE/optee_os/pull/6880#issuecomment-2160979548
Link: https://github.com/OP-TEE/optee_os/pull/6993#issuecomment-2290665315
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>