### PR TITLE
qemu_v8: update URL of TFA on GitHub

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -13,7 +13,7 @@
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="ec3eefd9de68a18d5acee1a151e0d93f6898807f" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.1.2" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="ARM-software/arm-trusted-firmware.git" revision="refs/tags/v2.10" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git" revision="refs/tags/v2.10" clone-depth="1" />
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                revision="refs/tags/v2.10" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />


### PR DESCRIPTION
https://github.com/ARM-software/arm-trusted-firmware is being deprecated in favor of https://github.com/TrustedFirmware-A/trusted-firmware-a, so use the new URL.

Suggested-by: Olivier Deprez <olivier.deprez@arm.com>