### PR TITLE
FVP: bump TF-A/Hafnium v2.11

### DIFF
--- a/fvp.xml
+++ b/fvp.xml
@@ -8,9 +8,9 @@
                 <linkfile src="fvp.mk" dest="build/Makefile" />
         </project>
 
-        <project path="hafnium"              name="hafnium/hafnium.git"                   revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.10" clone-depth="1" remote="tfo" />
-        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.4.0" />
+        <project path="hafnium"              name="hafnium/hafnium.git"                   revision="a33eca9976006ac9b08ed4afe6260a2e8b9d2b3a" clone-depth="1" remote="tfo" />
+        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.11" clone-depth="1" remote="tfo" />
+        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2024.04" remote="u-boot" clone-depth="1" />
 
         <!-- fTPM implementation -->


### PR DESCRIPTION
TF-A pinned to v2.11 tag.
Hafnium pinned to v2.11+ commit hash permitting to build using clang 18
mbedTLS bumped to v3.6.0 recommended to be used along with TF-A v2.11.

Needed by https://github.com/OP-TEE/build/pull/781