### PR TITLE
Move to SCP-firmware to the new v2.15.0 tag 

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -17,5 +17,5 @@
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                revision="refs/tags/v2.10" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />
-        <project path="SCP-firmware"         name="firmware/SCP-firmware.git"             revision="3d1b98e38686889c5a7b1d91a8c0f22fcfedbbf7" remote="arm-gitlab" clone-depth="1" />
+        <project path="SCP-firmware"         name="firmware/SCP-firmware.git"             revision="refs/tags/v2.15.0" remote="arm-gitlab" clone-depth="1" />
 </manifest>

--- a/stm32mp1.xml
+++ b/stm32mp1.xml
@@ -13,7 +13,7 @@
         <project path="edk2"                 name="tianocore/edk2.git" revision="refs/tags/edk2-stable202211" sync-s="true" clone-depth="1" />
         <project path="edk2-platforms"       name="tianocore/edk2-platforms.git" revision="5b9002e5f9119a832918c479071d18796349f3f1" sync-s="true" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git" revision="refs/tags/mbedtls-2.28.1" clone-depth="1" />
-        <project path="scp-firmware"         name="firmware/SCP-firmware.git" revision="3d1b98e38686889c5a7b1d91a8c0f22fcfedbbf7" remote="arm-gitlab" clone-depth="1" />
+        <project path="scp-firmware"         name="firmware/SCP-firmware.git" revision="refs/tags/v2.15.0" remote="arm-gitlab" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git" revision="refs/tags/v2.9" remote="tfo" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git" revision="refs/tags/v2024.01-rc1" remote="u-boot" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
SCP-firmware has released its new version v2.15.0 mid september. Move both qemu_v8 and stm32mp1 to use this official tag instead of the intermediate sha1. My 1st goal is to move qemu_v8 on this official version but I also made the change for stm32mp1 as they are following the same paths for SCMI server. This has been tested on qemu_v8 but not on stm32mp1. @etienne-lms could you test it ? Or should I remove stm32mp1 from this pull request ?