### PR TITLE
qemu_v8: update to TF-A/Hafnium v2.11

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -10,11 +10,11 @@
         </project>
 
         <!-- Misc gits -->
-        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                   revision="refs/tags/mbedtls-2.26.0" clone-depth="1" />
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="ec3eefd9de68a18d5acee1a151e0d93f6898807f" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.1.2" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git" revision="refs/tags/v2.10" clone-depth="1" />
-        <project path="hafnium"              name="TF-Hafnium/hafnium.git"                revision="refs/tags/v2.10" clone-depth="1" />
+        <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="a33eca9976006ac9b08ed4afe6260a2e8b9d2b3a" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.11" clone-depth="1" />
+        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />
         <project path="SCP-firmware"         name="firmware/SCP-firmware.git"             revision="3d1b98e38686889c5a7b1d91a8c0f22fcfedbbf7" remote="arm-gitlab" clone-depth="1" />


### PR DESCRIPTION
TF-A pinned to v2.11 tag. Hafnium pinned to v2.11+ commit hash permitting to build using clang 18.  mbedTLS bumped to v3.6.0 recommended to be used along with TF-A v2.11

Change-Id: If54f880ff6d61e47ecc2c6e955b63525a6c3546b