### PR TITLE
qemu_v8: upgrade Xen to RELEASE-4.19.0

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -16,6 +16,6 @@
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.12" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
-        <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.18.0" clone-depth="1" remote="xenbits" />
+        <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.19.0" clone-depth="1" remote="xenbits" />
         <project path="SCP-firmware"         name="firmware/SCP-firmware.git"             revision="refs/tags/v2.15.0" remote="arm-gitlab" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Upgrade Xen to RELEASE-4.19.0. This add support for FF-A notifications and avoids problems with kernels after v6.6.