### PR TITLE
qemu_v8: upgrade QEMU to v9.2.0

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -11,7 +11,7 @@
 
         <!-- Misc gits -->
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="ec3eefd9de68a18d5acee1a151e0d93f6898807f" />
-        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v8.1.2" clone-depth="1" />
+        <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v9.2.0" clone-depth="1" />
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="a33eca9976006ac9b08ed4afe6260a2e8b9d2b3a" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.12" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />


### PR DESCRIPTION
Upgrade QEMU to v9.2.0. This is needed to avoid error with the latest kernel like:
```
ERROR:../target/arm/internals.h:760:regime_is_user: code should not be reached Bail out!
ERROR:../target/arm/internals.h:760:regime_is_user: code should not be reached make: 
*** [Makefile:571: run-only] Aborted (core dumped)
```

Depends on https://github.com/OP-TEE/build/pull/798