### PR TITLE
qemu_v8: add Trusted Services support

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -18,4 +18,7 @@
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.19.0" clone-depth="1" remote="xenbits" />
         <project path="SCP-firmware"         name="firmware/SCP-firmware.git"             revision="refs/tags/v2.15.0" remote="arm-gitlab" clone-depth="1" />
+
+        <project path="trusted-services"     name="TS/trusted-services.git"                  revision="refs/tags/v1.1.0" remote="tfo" clone-depth="1" />
+        <project path="linux-arm-ffa-user"   name="linux-arm/linux-trusted-services.git" revision="refs/tags/debugfs-v5.0.2"     clone-depth="1" remote="arm-gitlab" />
 </manifest>


### PR DESCRIPTION
Add the Trusted Services git (v1.1.0) and the out-of-tree linux-arm-ffa-user (debugfs-v5.0.2) kernel driver for testing.