### PR TITLE
qemu_v8: add missing remote "tfo"

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
+        <remote name="tfo"    fetch="https://git.trustedfirmware.org" />
         <remote name="u-boot"   fetch="https://source.denx.de/u-boot" />
         <remote name="xenbits"  fetch="https://xenbits.xen.org/" />
         <remote name="arm-gitlab"       fetch="https://git.gitlab.arm.com/" />


### PR DESCRIPTION
Add missing remote "tfo", from which `repo` will try to fetch newly added Trusted Services project. This resolves the following error that occurred when trying to `repo sync`.

```
fatal: remote tfo not defined in /home/optee/qemu-optee/.repo/manifest.xml
```