### PR TITLE
qemu_v8: upgrade scp firmware to v2.16.0

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -17,7 +17,7 @@
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.20.0" clone-depth="1" remote="xenbits" />
-        <project path="SCP-firmware"         name="linaro-swg/SCP-firmware.git"             revision="refs/tags/v2.15.0" clone-depth="1" />
+        <project path="SCP-firmware"         name="linaro-swg/SCP-firmware.git"             revision="refs/tags/v2.16.0" clone-depth="1" />
 
         <project path="trusted-services"     name="TS/trusted-services.git"                  revision="8881aaa3a9cb21e8b869e28c1a079f02fa46fd6c" remote="tfo" clone-depth="1" />
         <project path="linux-arm-ffa-user"   name="linaro-swg/linux-trusted-services.git" revision="refs/tags/debugfs-v5.0.2"     clone-depth="1" />


### PR DESCRIPTION
Upgrade SCP-firmware version to v2.16.0 which has been released mid march and includes the fix for the scp notification compilation among other things.