### PR TITLE
qemu_v8: Update U-Boot to v2025.07-rc1

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -15,7 +15,7 @@
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.12" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.12" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />
-        <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />
+        <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2025.07-rc1" remote="u-boot" clone-depth="1" />
         <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.20.0" clone-depth="1" remote="xenbits" />
         <project path="SCP-firmware"         name="linaro-swg/SCP-firmware.git"             revision="refs/tags/v2.16.0" clone-depth="1" />
 


### PR DESCRIPTION
Update U-Boot to v2025.07-rc1.

This patch depends on: https://github.com/OP-TEE/build/pull/821