### PR TITLE
qemu_v8: hafnium: synchronize submodules on checkout

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -12,7 +12,7 @@
         <!-- Misc gits -->
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="ec3eefd9de68a18d5acee1a151e0d93f6898807f" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v10.0.0" clone-depth="1" />
-        <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.12" clone-depth="1" />
+        <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.12" sync-s="true" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.12" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2023.07.02" remote="u-boot" clone-depth="1" />


### PR DESCRIPTION
When doing the "repo sync", Hafnium needs to be checked out in full including its submodules (prebuilt etc.) because it won't do it automatically when building. To do that, add sync-s="true".

Fixes: 9dd49cf8e39b ("qemu_v8: upgrade hafnium to v2.12")