### PR TITLE
qemu_v8: clone Xen from its GitHub mirror

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -2,7 +2,6 @@
 <manifest>
         <remote name="tfo"    fetch="https://git.trustedfirmware.org" />
         <remote name="u-boot"   fetch="https://source.denx.de/u-boot" />
-        <remote name="xenbits"  fetch="https://xenbits.xen.org/" />
 
         <include name="common.xml" />
         <project path="build"                name="OP-TEE/build.git">
@@ -16,7 +15,7 @@
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.12" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />
         <project path="u-boot"               name="u-boot.git"                            revision="refs/tags/v2025.07-rc1" remote="u-boot" clone-depth="1" />
-        <project path="xen"                 name="git-http/xen.git"                         revision="refs/tags/RELEASE-4.20.0" clone-depth="1" remote="xenbits" />
+        <project path="xen"                  name="xen-project/xen.git"                   revision="refs/tags/RELEASE-4.20.0" clone-depth="1" />
         <project path="SCP-firmware"         name="linaro-swg/SCP-firmware.git"             revision="refs/tags/v2.16.0" clone-depth="1" />
 
         <project path="trusted-services"     name="TS/trusted-services.git"                  revision="8881aaa3a9cb21e8b869e28c1a079f02fa46fd6c" remote="tfo" clone-depth="1" />


### PR DESCRIPTION
Use https://github.com/xen-project/xen.git rather than https://xenbits.xen.org/git-http/xen.git for reliability reasons. From the OP-TEE OS CI logs:

 repo has been initialized in /__w/optee_test/optee_repo_qemu_v8
 error: Cannot fetch git-http/xen.git from https://xenbits.xen.org/git-http/xen.git
 fatal: unable to access 'https://xenbits.xen.org/git-http/xen.git/': Failed to connect to xenbits.xen.org port 443 after 135097 ms: Could not connect to server