### PR TITLE
common: update buildroot to 2025.05

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -14,7 +14,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- buildroot git -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2024.05" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2025.05" clone-depth="1" />
 
         <!-- fTPM implementation -->
         <project path="ms-tpm-20-ref"        name="microsoft/ms-tpm-20-ref"               revision="98b60a44aba79b15fcce1c0d1e46cf5918400f6a" clone-depth="1" />


### PR DESCRIPTION
Buildroot 2025.05 upgrades GNU m4 to version 1.4.20 (from 1.4.19 in Buildroot 2024.5) which among other things brings in a fix for building when the host compiler is GCC 15.

Link: https://lists.buildroot.org/pipermail/buildroot/2025-May/777741.html