### PR TITLE
update raspberry pi firmware to be able to use rev 1.4 of raspberry pi 3b+ board

### DIFF
--- a/rpi3.xml
+++ b/rpi3.xml
@@ -11,7 +11,7 @@
         <project path="linux"                name="linaro-swg/linux.git"                  revision="rpi3-optee-6.7" clone-depth="1" />
 
         <!-- Misc gits -->
-        <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20190401" clone-depth="1" />
+        <project path="firmware"             name="raspberrypi/firmware.git"              revision="refs/tags/1.20230405" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo"/>
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2021.10" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Also needed changes in uboot.env.txt for raspberry are in this pull request:
https://github.com/OP-TEE/build/pull/847