### PR TITLE
qemu_v8: rust: pin the latest version

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -8,7 +8,7 @@
         </project>
 
         <!-- Misc gits -->
-        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="e67293c0d2f8168f47586be2e5b1a4231c8bd8e9" />
+        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="a8cb34150770ba729b2cc9b3c1d7c014bd32d95b" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v10.0.0" clone-depth="1" />
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.12" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.13-rc0" clone-depth="1" />


### PR DESCRIPTION
Fix the optee os CI error caused by building Rust examples.

related: https://github.com/apache/teaclave-trustzone-sdk/pull/241