### PR TITLE
qemuv8: update TF-A and Hafnium to v2.14.0 and MBed TLS to v3.6.5

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -10,9 +10,9 @@
         <!-- Misc gits -->
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="a8cb34150770ba729b2cc9b3c1d7c014bd32d95b" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v10.0.0" clone-depth="1" />
-        <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.12" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.13-rc0" clone-depth="1" />
-        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.0" clone-depth="1" />
+        <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.14.0" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.14.0" clone-depth="1" />
+        <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.5" sync-s="true" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2025.07"  clone-depth="1" />
         <project path="xen"                  name="xen-project/xen.git"                   revision="refs/tags/RELEASE-4.20.0" clone-depth="1" />
         <project path="SCP-firmware"         name="linaro-swg/SCP-firmware.git"             revision="refs/tags/v2.16.0" clone-depth="1" />


### PR DESCRIPTION
Use the latest releases of TF-A and Hafnium. Update MBedTLS too to satisfy dependencies. sync-s="true" is reportedly needed for the build although my tests did not demonstrate it. The only submodule in mbedtls is only 6MB in size anyways.