### PR TITLE
qemu_v8: use sync-s="true" for trusted-firmware-a

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -11,7 +11,7 @@
         <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="a8cb34150770ba729b2cc9b3c1d7c014bd32d95b" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v10.0.0" clone-depth="1" />
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.14.0" clone-depth="1" />
-        <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.14.0" clone-depth="1" />
+        <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.14.0" sync-s="true" clone-depth="1" />
         <project path="mbedtls"              name="Mbed-TLS/mbedtls.git"                  revision="refs/tags/mbedtls-3.6.5" sync-s="true" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2025.07"  clone-depth="1" />
         <project path="xen"                  name="xen-project/xen.git"                   revision="refs/tags/RELEASE-4.20.0" clone-depth="1" />


### PR DESCRIPTION
Trusted Firmare-A v2.14 needs to be cloned with its submodules properly initialized. For this, add sync-s="true" (which is equivalent to running 'git submodule update --init' after cloning). Fixes CI errors in the "FW handoff" and "SMPC_AT_EL=2" QEMUv8 jobs.