### PR TITLE
qemu_v8: rust: pin the latest version

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -8,7 +8,7 @@
         </project>
 
         <!-- Misc gits -->
-        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="a8cb34150770ba729b2cc9b3c1d7c014bd32d95b" />
+        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="bb6bdb2e6d71e45cbdc7e2401d4b17e5dd9b51dc" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v10.0.0" clone-depth="1" />
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.14.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.14.0" sync-s="true" clone-depth="1" />

--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -8,7 +8,7 @@
         </project>
 
         <!-- Misc gits -->
-        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="bb6bdb2e6d71e45cbdc7e2401d4b17e5dd9b51dc" />
+        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="bb6bdb2e6d71e45cbdc7e2401d4b17e5dd9b51dc" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v10.0.0" clone-depth="1" />
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.14.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.14.0" sync-s="true" clone-depth="1" />


### PR DESCRIPTION
Resolve CI failures in OP-TEE/optee_os#7690 by ensuring the linker script is correctly preprocessed during the build phase.