### PR TITLE
versal: Update to AMD/Xilinx v2024.2

### DIFF
--- a/versal.xml
+++ b/versal.xml
@@ -12,4 +12,6 @@
 	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
 	<project path="linux"			name="Xilinx/linux-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
 	<project path="bootgen"			name="Xilinx/bootgen.git"		revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
+
+	<project path="embeddedsw"		name="Xilinx/embeddedsw.git"		revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
 </manifest>

--- a/versal.xml
+++ b/versal.xml
@@ -7,11 +7,9 @@
 
 	<remove-project                         name="linaro-swg/linux.git" />
 
-	<!-- Private maintainer git - Xilinx adoption work is in progress -->
-	<project path="arm-trusted-firmware"	name="ldts/arm-trusted-firmware.git"  revision="refs/heads/xlnx-v2.7-versal" clone-depth="1" />
-
 	<!-- Xilinx gits -->
-	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"	revision="refs/tags/xilinx-v2022.1" clone-depth="1" />
-	<project path="linux"			name="Xilinx/linux-xlnx.git"	revision="refs/tags/xilinx-v2022.1" clone-depth="1" />
-	<project path="bootgen"			name="Xilinx/bootgen.git"	revision="refs/tags/xilinx_v2022.1" clone-depth="1" />
+	<project path="arm-trusted-firmware"	name="Xilinx/arm-trusted-firmware.git"	revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
+	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
+	<project path="linux"			name="Xilinx/linux-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
+	<project path="bootgen"			name="Xilinx/bootgen.git"		revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
 </manifest>

--- a/versal.xml
+++ b/versal.xml
@@ -8,10 +8,10 @@
 	<remove-project                         name="linaro-swg/linux.git" />
 
 	<!-- Private maintainer git - Xilinx adoption work is in progress -->
-	<project path="arm-trusted-firmware"	name="ldts/arm-trusted-firmware.git"  revision="refs/heads/xlnx-v2.7-versal"/>
+	<project path="arm-trusted-firmware"	name="ldts/arm-trusted-firmware.git"  revision="refs/heads/xlnx-v2.7-versal" clone-depth="1" />
 
 	<!-- Xilinx gits -->
-	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"	revision="refs/tags/xilinx-v2022.1"/>
-	<project path="linux"			name="Xilinx/linux-xlnx.git"	revision="refs/tags/xilinx-v2022.1"/>
-	<project path="bootgen"			name="Xilinx/bootgen.git"	revision="refs/tags/xilinx_v2022.1"/>
+	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"	revision="refs/tags/xilinx-v2022.1" clone-depth="1" />
+	<project path="linux"			name="Xilinx/linux-xlnx.git"	revision="refs/tags/xilinx-v2022.1" clone-depth="1" />
+	<project path="bootgen"			name="Xilinx/bootgen.git"	revision="refs/tags/xilinx_v2022.1" clone-depth="1" />
 </manifest>

--- a/versal_net.xml
+++ b/versal_net.xml
@@ -11,5 +11,5 @@
         <project path="arm-trusted-firmware"	name="ARM-software/arm-trusted-firmware.git"	revision="refs/tags/lts-v2.10.12" clone-depth="1" />
         <project path="u-boot"			name="u-boot/u-boot.git"			revision="refs/tags/v2025.01" clone-depth="1" />
         <project path="linux"			name="Xilinx/linux-xlnx.git"			revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
-        <project path="bootgen"			name="Xilinx/bootgen.git"			revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
+        <project path="bootgen"			name="Xilinx/bootgen.git"			revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
 </manifest>

--- a/versal_net.xml
+++ b/versal_net.xml
@@ -12,4 +12,6 @@
 	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
 	<project path="linux"			name="Xilinx/linux-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
 	<project path="bootgen"			name="Xilinx/bootgen.git"		revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
+
+	<project path="embeddedsw"		name="Xilinx/embeddedsw.git"		revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
 </manifest>

--- a/versal_net.xml
+++ b/versal_net.xml
@@ -8,8 +8,8 @@
 	<remove-project                         name="linaro-swg/linux.git" />
 
 	<!-- Xilinx gits -->
-        <project path="arm-trusted-firmware"	name="ARM-software/arm-trusted-firmware.git"	revision="refs/tags/lts-v2.10.12" clone-depth="1" />
-        <project path="u-boot"			name="u-boot/u-boot.git"			revision="refs/tags/v2025.01" clone-depth="1" />
-        <project path="linux"			name="Xilinx/linux-xlnx.git"			revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
-        <project path="bootgen"			name="Xilinx/bootgen.git"			revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
+	<project path="arm-trusted-firmware"	name="Xilinx/arm-trusted-firmware.git"	revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
+	<project path="u-boot"			name="Xilinx/u-boot-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
+	<project path="linux"			name="Xilinx/linux-xlnx.git"		revision="refs/tags/xilinx-v2024.2" clone-depth="1" />
+	<project path="bootgen"			name="Xilinx/bootgen.git"		revision="refs/tags/xilinx_v2024.2" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
This pull request is build on top of previous work by @jcorbier & Co in merged PR #311 (and unmerged/open PR #312 ; replaced by this PR).

This pull request extends the existing AMD/Xilinx Versal ACAP and NET manifests regarding the following aspects:

* Various minor fixes
* Add checkout of AMD/Xilinx embeddedsw for building custom PLM and PSM Firmware
* Update to AMD/Xilinx release v2024.2 for Versal ACAP, too; no more third-party ATF

This pull request depends on and shall be merged after [optee_os.git PR #7726](https://github.com/OP-TEE/optee_os/pull/7726) and [build.git PR #857](https://github.com/OP-TEE/build/pull/857) have been merged.

See [optee_docs.git PR #280](https://github.com/OP-TEE/optee_docs/pull/280) for updated documentation.