### PR TITLE
qemu_v8: rust: pin the latest version

### DIFF
--- a/qemu_v8.xml
+++ b/qemu_v8.xml
@@ -8,7 +8,7 @@
         </project>
 
         <!-- Misc gits -->
-        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="79bc5bd17fa54e2f03fcbbb61f08a0f06a71f6a2" clone-depth="1" />
+        <project path="optee_rust"           name="apache/incubator-teaclave-trustzone-sdk.git"            revision="746ee39f286788c049ddb55f57417ba97ed575a7" clone-depth="1" />
         <project path="qemu"                 name="qemu/qemu.git"                         revision="refs/tags/v10.0.0" clone-depth="1" />
         <project path="hafnium"              name="TF-Hafnium/hafnium.git"                   revision="refs/tags/v2.14.0" clone-depth="1" />
         <project path="trusted-firmware-a"   name="TrustedFirmware-A/trusted-firmware-a.git"           revision="refs/tags/v2.14.0" sync-s="true" clone-depth="1" />


### PR DESCRIPTION
Upgrades the toolchain version to mitigate MSRV conflicts introduced by downstream crates and ensures long-term build stability.

Relative changes: https://github.com/apache/teaclave-trustzone-sdk/commit/4583051524f8d05626d85cf4acdc03b70a69df4e#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eR21