### PR TITLE
imx: switch IMX TF-A fork and version v2.12

### DIFF
--- a/imx.xml
+++ b/imx.xml
@@ -9,7 +9,7 @@
         </project>
 
         <!-- Misc gits -->
-        <project path="trusted-firmware-a"   name="TF-A/trusted-firmware-a.git"           revision="refs/tags/v2.6" clone-depth="1" remote="tfo" />
+        <project path="trusted-firmware-a"   name="nxp-imx/imx-atf.git"           revision="refs/tags/lf-6.18.2-1.0.0" clone-depth="1" />
         <project path="u-boot"               name="u-boot/u-boot.git"                     revision="refs/tags/v2020.10-rc2" clone-depth="1" />
         <project path="imx-mkimage"          name="nxp-imx/imx-mkimage.git"                       revision="refs/tags/rel_imx_5.4.24_2.1.0" clone-depth="1" />
 </manifest>


### PR DESCRIPTION
Switch IMX TF-A fork and update version to lf-6.18.2-1.0.0 based on TF-A version 2.12.

Depends on https://github.com/OP-TEE/build/pull/858