### PR TITLE
common: update buildroot to 2026.02.2

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -14,7 +14,7 @@
         <project path="optee_examples"       name="linaro-swg/optee_examples.git" />
 
         <!-- buildroot git -->
-        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2025.05" clone-depth="1" />
+        <project path="buildroot"            name="buildroot/buildroot.git"               revision="refs/tags/2026.02.2" clone-depth="1" />
 
         <!-- fTPM implementation -->
         <project path="ms-tpm-20-ref"        name="microsoft/ms-tpm-20-ref"               revision="98b60a44aba79b15fcce1c0d1e46cf5918400f6a" clone-depth="1" />


### PR DESCRIPTION
Fixes https://github.com/OP-TEE/manifest/issues/347

Buildroot since 2025.11.2 upgrades its GNU m4 package version to 1.4.21 which fixes build problems related to ISO C23.
This commit updates buildroot from 2025.5 (EOL) -> 2026.02.2 (latest stable). Tested against qemu_v8.

Link: https://linux.debian.bugs.dist.narkive.com/R6mYKigK