### PR TITLE
versal2: add qemu,qemu-devicetree and bootgen projects

### DIFF
--- a/versal2.xml
+++ b/versal2.xml
@@ -11,4 +11,7 @@
 	<project path="arm-trusted-firmware"	name="Xilinx/arm-trusted-firmware.git"	revision="xlnx_rebase_v2.14" />
 	<project path="u-boot-xlnx"		name="Xilinx/u-boot-xlnx.git"	revision="xlnx_rebase_v2026.01" />
 	<project path="linux-xlnx"		name="Xilinx/linux-xlnx.git"	revision="xlnx_rebase_v6.18_LTS" />
+	<project path="qemu"                    name="Xilinx/qemu.git"                  revision="master" />
+	<project path="qemu-devicetrees"        name="Xilinx/qemu-devicetrees.git"  revision="master" />
+	<project path="bootgen"                 name="Xilinx/bootgen.git"               revision="xlnx_rel_v2026.1" />
 </manifest>


### PR DESCRIPTION
Add project entries for QEMU, QEMU device trees and bootgen required for multi-architecture simulation support.

- qemu: Xilinx QEMU (master) for multi-arch simulation (aarch64, microblazeel, riscv32)
- qemu-devicetrees: Xilinx QEMU device trees (master)
- bootgen: Xilinx bootgen tool for creating BOOT.BIN and OSPI flash image